### PR TITLE
Changed jar and distribution names to be the same everywhere

### DIFF
--- a/buildSrc/src/main/kotlin/aiven-apache-kafka-connectors-all.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/aiven-apache-kafka-connectors-all.java-conventions.gradle.kts
@@ -17,6 +17,8 @@
 import com.diffplug.spotless.LineEnding
 import java.net.URI
 
+group = "io.aiven"
+
 plugins {
 
     // https://docs.gradle.org/current/userguide/java_library_plugin.html

--- a/buildSrc/src/main/kotlin/aiven-apache-kafka-connectors-all.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/aiven-apache-kafka-connectors-all.java-conventions.gradle.kts
@@ -65,6 +65,14 @@ tasks.withType<Javadoc> {
     (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:all,-missing", "-quiet")
 }
 
+tasks.withType<Jar> {
+    archiveBaseName.set(project.name + "-for-apache-kafka")
+    manifest { attributes(mapOf("Version" to project.version)) }
+    from("${project.rootDir}/LICENSE") {
+        into("META-INF")
+    }
+}
+
 jacoco {
     toolVersion = "0.8.7"
 }

--- a/buildSrc/src/main/kotlin/aiven-apache-kafka-connectors-all.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/aiven-apache-kafka-connectors-all.java-conventions.gradle.kts
@@ -162,6 +162,7 @@ spotless {
 
 distributions {
     main {
+        distributionBaseName.set(project.name + "-for-apache-kafka")
         contents {
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
             from(tasks.jar)

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -92,6 +92,8 @@ dependencies {
   testRuntimeOnly(logginglibs.logback.classic)
 }
 
+tasks.withType<Jar> { archiveBaseName.set(project.name + "-for-apache-kafka-connect") }
+
 publishing {
   publications {
     create<MavenPublication>("publishMavenJavaArtifact") {

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -94,6 +94,8 @@ dependencies {
 
 tasks.withType<Jar> { archiveBaseName.set(project.name + "-for-apache-kafka-connect") }
 
+distributions { main { distributionBaseName.set(project.name + "-for-apache-kafka-connect") } }
+
 publishing {
   publications {
     create<MavenPublication>("publishMavenJavaArtifact") {

--- a/gcs-sink-connector/build.gradle.kts
+++ b/gcs-sink-connector/build.gradle.kts
@@ -175,8 +175,6 @@ tasks.processResources {
   }
 }
 
-tasks.jar { manifest { attributes(mapOf("Version" to project.version)) } }
-
 publishing {
   publications {
     create<MavenPublication>("publishMavenJavaArtifact") {

--- a/s3-sink-connector/build.gradle.kts
+++ b/s3-sink-connector/build.gradle.kts
@@ -162,8 +162,6 @@ tasks.processResources {
   }
 }
 
-tasks.jar { manifest { attributes(mapOf("Version" to project.version)) } }
-
 publishing {
   publications {
     create<MavenPublication>("publishMavenJavaArtifact") {


### PR DESCRIPTION
We had different names for various producer artifacts(zip/tar/jar/Maven Central). Made the aligned with the current naming agreement.