### PR TITLE
ensure timestamp is stable for a record

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/StableTimeFormatter.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/StableTimeFormatter.java
@@ -1,11 +1,28 @@
-package io.aiven.kafka.connect.common.config;
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import io.aiven.kafka.connect.common.templating.VariableTemplatePart;
-import org.apache.kafka.connect.sink.SinkRecord;
+package io.aiven.kafka.connect.common.config;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.function.Function;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.templating.VariableTemplatePart;
 
 public class StableTimeFormatter {
     private static final Map<String, DateTimeFormatter> TIMESTAMP_FORMATTERS = Map.of("yyyy",
@@ -14,14 +31,13 @@ public class StableTimeFormatter {
 
     private final Function<SinkRecord, Function<VariableTemplatePart.Parameter, String>> formatter;
 
-    public StableTimeFormatter(TimestampSource timestampSource) {
+    public StableTimeFormatter(final TimestampSource timestampSource) {
         this.formatter = record -> {
-            var time =  timestampSource.time(record);
-            return parameter -> time
-                    .format(TIMESTAMP_FORMATTERS.get(parameter.getValue()));
+            final var time = timestampSource.time(record);
+            return parameter -> time.format(TIMESTAMP_FORMATTERS.get(parameter.getValue()));
         };
     }
-    public Function<VariableTemplatePart.Parameter, String> apply(SinkRecord record) {
+    public Function<VariableTemplatePart.Parameter, String> apply(final SinkRecord record) {
         return formatter.apply(record);
     }
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/StableTimeFormatter.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/StableTimeFormatter.java
@@ -1,0 +1,27 @@
+package io.aiven.kafka.connect.common.config;
+
+import io.aiven.kafka.connect.common.templating.VariableTemplatePart;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.function.Function;
+
+public class StableTimeFormatter {
+    private static final Map<String, DateTimeFormatter> TIMESTAMP_FORMATTERS = Map.of("yyyy",
+            DateTimeFormatter.ofPattern("yyyy"), "MM", DateTimeFormatter.ofPattern("MM"), "dd",
+            DateTimeFormatter.ofPattern("dd"), "HH", DateTimeFormatter.ofPattern("HH"));
+
+    private final Function<SinkRecord, Function<VariableTemplatePart.Parameter, String>> formatter;
+
+    public StableTimeFormatter(TimestampSource timestampSource) {
+        this.formatter = record -> {
+            var time =  timestampSource.time(record);
+            return parameter -> time
+                    .format(TIMESTAMP_FORMATTERS.get(parameter.getValue()));
+        };
+    }
+    public Function<VariableTemplatePart.Parameter, String> apply(SinkRecord record) {
+        return formatter.apply(record);
+    }
+}

--- a/commons/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionKeyRecordGrouper.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionKeyRecordGrouper.java
@@ -16,7 +16,6 @@
 
 package io.aiven.kafka.connect.common.grouper;
 
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,21 +24,17 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-import io.aiven.kafka.connect.common.config.StableTimeFormatter;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import io.aiven.kafka.connect.common.config.FilenameTemplateVariable;
+import io.aiven.kafka.connect.common.config.StableTimeFormatter;
 import io.aiven.kafka.connect.common.config.TimestampSource;
 import io.aiven.kafka.connect.common.templating.Template;
 import io.aiven.kafka.connect.common.templating.VariableTemplatePart.Parameter;
 
 public class TopicPartitionKeyRecordGrouper implements RecordGrouper {
-
-    private static final Map<String, DateTimeFormatter> TIMESTAMP_FORMATTERS = Map.of("yyyy",
-            DateTimeFormatter.ofPattern("yyyy"), "MM", DateTimeFormatter.ofPattern("MM"), "dd",
-            DateTimeFormatter.ofPattern("dd"), "HH", DateTimeFormatter.ofPattern("HH"));
 
     private final Template filenameTemplate;
 

--- a/commons/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionRecordGrouper.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionRecordGrouper.java
@@ -24,11 +24,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-import io.aiven.kafka.connect.common.config.StableTimeFormatter;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import io.aiven.kafka.connect.common.config.FilenameTemplateVariable;
+import io.aiven.kafka.connect.common.config.StableTimeFormatter;
 import io.aiven.kafka.connect.common.config.TimestampSource;
 import io.aiven.kafka.connect.common.templating.Template;
 import io.aiven.kafka.connect.common.templating.VariableTemplatePart.Parameter;

--- a/commons/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionRecordGrouper.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionRecordGrouper.java
@@ -16,7 +16,6 @@
 
 package io.aiven.kafka.connect.common.grouper;
 
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
+import io.aiven.kafka.connect.common.config.StableTimeFormatter;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -45,17 +45,13 @@ import io.aiven.kafka.connect.common.templating.VariableTemplatePart.Parameter;
  */
 class TopicPartitionRecordGrouper implements RecordGrouper {
 
-    private static final Map<String, DateTimeFormatter> TIMESTAMP_FORMATTERS = Map.of("yyyy",
-            DateTimeFormatter.ofPattern("yyyy"), "MM", DateTimeFormatter.ofPattern("MM"), "dd",
-            DateTimeFormatter.ofPattern("dd"), "HH", DateTimeFormatter.ofPattern("HH"));
-
     private final Template filenameTemplate;
 
     private final Map<TopicPartition, SinkRecord> currentHeadRecords = new HashMap<>();
 
     private final Map<String, List<SinkRecord>> fileBuffers = new HashMap<>();
 
-    private final Function<SinkRecord, Function<Parameter, String>> setTimestampBasedOnRecord;
+    private final StableTimeFormatter timeFormatter;
 
     private final Rotator<List<SinkRecord>> rotator;
 
@@ -75,8 +71,7 @@ class TopicPartitionRecordGrouper implements RecordGrouper {
         Objects.requireNonNull(tsSource, "tsSource cannot be null");
         this.filenameTemplate = filenameTemplate;
 
-        this.setTimestampBasedOnRecord = record -> parameter -> tsSource.time(record)
-                .format(TIMESTAMP_FORMATTERS.get(parameter.getValue()));
+        this.timeFormatter = new StableTimeFormatter(tsSource);
 
         this.rotator = buffer -> {
             final var unlimited = maxRecordsPerFile == null;
@@ -119,7 +114,7 @@ class TopicPartitionRecordGrouper implements RecordGrouper {
                 .bindVariable(FilenameTemplateVariable.TOPIC.name, topicPartition::topic)
                 .bindVariable(FilenameTemplateVariable.PARTITION.name, setKafkaPartition)
                 .bindVariable(FilenameTemplateVariable.START_OFFSET.name, setKafkaOffset)
-                .bindVariable(FilenameTemplateVariable.TIMESTAMP.name, setTimestampBasedOnRecord.apply(currentRecord))
+                .bindVariable(FilenameTemplateVariable.TIMESTAMP.name, timeFormatter.apply(currentRecord))
                 .render();
     }
 

--- a/commons/src/test/java/io/aiven/kafka/connect/common/config/StableTimeFormatterTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/config/StableTimeFormatterTest.java
@@ -1,0 +1,45 @@
+package io.aiven.kafka.connect.common.config;
+
+import io.aiven.kafka.connect.common.templating.Template;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StableTimeFormatterTest {
+    private final TimestampSource timestampSource = new TimestampSource() {
+        int counter = 10;
+        @Override
+        public ZonedDateTime time(SinkRecord record) {
+            return ZonedDateTime.of(2021, 2, 3, counter++, 4, 5, 0, ZoneOffset.UTC);
+        }
+
+        @Override
+        public Type type() {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    @Test
+    void testStableTime() {
+        Template template = Template.of( "yy-{{timestamp:unit=yyyy}},MM-{{timestamp:unit=MM}},dd-{{timestamp:unit=dd}},HH1-{{timestamp:unit=HH}},HH2-{{timestamp:unit=HH}}");
+
+        final var stableTimeFormatter = new StableTimeFormatter(timestampSource);
+        final var currentRecord = new SinkRecord("topic", 0, null, null, null, null, 0);
+        var result = template.instance()
+                .bindVariable(FilenameTemplateVariable.TIMESTAMP.name, stableTimeFormatter.apply(currentRecord))
+                .render();
+        //used to be yy-2021,MM-02,dd-03,HH1-13,HH2-14, if we dont cache the time
+        assertEquals("yy-2021,MM-02,dd-03,HH1-10,HH2-10", result);
+
+        var result2 = template.instance()
+                .bindVariable(FilenameTemplateVariable.TIMESTAMP.name, stableTimeFormatter.apply(currentRecord))
+                .render();
+        //ensure time isnt cached across records
+        assertEquals("yy-2021,MM-02,dd-03,HH1-11,HH2-11", result2);
+    }
+
+}

--- a/commons/src/test/java/io/aiven/kafka/connect/common/config/StableTimeFormatterTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/config/StableTimeFormatterTest.java
@@ -1,19 +1,37 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.common.config;
 
-import io.aiven.kafka.connect.common.templating.Template;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.templating.Template;
+
+import org.junit.jupiter.api.Test;
 
 class StableTimeFormatterTest {
     private final TimestampSource timestampSource = new TimestampSource() {
         int counter = 10;
         @Override
-        public ZonedDateTime time(SinkRecord record) {
+        public ZonedDateTime time(final SinkRecord record) {
             return ZonedDateTime.of(2021, 2, 3, counter++, 4, 5, 0, ZoneOffset.UTC);
         }
 
@@ -25,20 +43,21 @@ class StableTimeFormatterTest {
 
     @Test
     void testStableTime() {
-        Template template = Template.of( "yy-{{timestamp:unit=yyyy}},MM-{{timestamp:unit=MM}},dd-{{timestamp:unit=dd}},HH1-{{timestamp:unit=HH}},HH2-{{timestamp:unit=HH}}");
+        final Template template = Template.of(
+                "yy-{{timestamp:unit=yyyy}},MM-{{timestamp:unit=MM}},dd-{{timestamp:unit=dd}},HH1-{{timestamp:unit=HH}},HH2-{{timestamp:unit=HH}}");
 
         final var stableTimeFormatter = new StableTimeFormatter(timestampSource);
         final var currentRecord = new SinkRecord("topic", 0, null, null, null, null, 0);
-        var result = template.instance()
+        final var result = template.instance()
                 .bindVariable(FilenameTemplateVariable.TIMESTAMP.name, stableTimeFormatter.apply(currentRecord))
                 .render();
-        //used to be yy-2021,MM-02,dd-03,HH1-13,HH2-14, if we dont cache the time
+        // used to be yy-2021,MM-02,dd-03,HH1-13,HH2-14, if we dont cache the time
         assertEquals("yy-2021,MM-02,dd-03,HH1-10,HH2-10", result);
 
-        var result2 = template.instance()
+        final var result2 = template.instance()
                 .bindVariable(FilenameTemplateVariable.TIMESTAMP.name, stableTimeFormatter.apply(currentRecord))
                 .render();
-        //ensure time isnt cached across records
+        // ensure time isnt cached across records
         assertEquals("yy-2021,MM-02,dd-03,HH1-11,HH2-11", result2);
     }
 

--- a/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/OldFullKeyFormatters.java
+++ b/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/OldFullKeyFormatters.java
@@ -16,13 +16,10 @@
 
 package io.aiven.kafka.connect.s3;
 
-import java.time.format.DateTimeFormatter;
-import java.util.Map;
 import java.util.function.BiFunction;
 
 import org.apache.kafka.connect.sink.SinkRecord;
 
-import io.aiven.kafka.connect.common.config.TimestampSource;
 import io.aiven.kafka.connect.common.templating.VariableTemplatePart;
 
 public final class OldFullKeyFormatters {

--- a/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/OldFullKeyFormatters.java
+++ b/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/OldFullKeyFormatters.java
@@ -31,15 +31,7 @@ public final class OldFullKeyFormatters {
                     ? String.format("%020d", sinkRecord.kafkaOffset())
                     : Long.toString(sinkRecord.kafkaOffset());
 
-    private static final Map<String, DateTimeFormatter> TIMESTAMP_FORMATTERS = Map.of("yyyy",
-            DateTimeFormatter.ofPattern("yyyy"), "MM", DateTimeFormatter.ofPattern("MM"), "dd",
-            DateTimeFormatter.ofPattern("dd"), "HH", DateTimeFormatter.ofPattern("HH"));
-
     private OldFullKeyFormatters() {
         /* hide constructor */ }
 
-    public static String timestamp(final SinkRecord record, final TimestampSource tsSource,
-            final VariableTemplatePart.Parameter parameter) {
-        return tsSource.time(record).format(TIMESTAMP_FORMATTERS.get(parameter.getValue()));
-    }
 }

--- a/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
+++ b/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import io.aiven.kafka.connect.common.config.StableTimeFormatter;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -38,6 +37,7 @@ import org.apache.kafka.connect.sink.SinkTask;
 
 import io.aiven.kafka.connect.common.config.FilenameTemplateVariable;
 import io.aiven.kafka.connect.common.config.FormatType;
+import io.aiven.kafka.connect.common.config.StableTimeFormatter;
 import io.aiven.kafka.connect.common.grouper.RecordGrouper;
 import io.aiven.kafka.connect.common.grouper.RecordGrouperFactory;
 import io.aiven.kafka.connect.common.output.OutputWriter;
@@ -168,7 +168,8 @@ public final class S3SinkTask extends SinkTask {
     private String oldFullKey(final SinkRecord record) {
         final var prefix = config.getPrefixTemplate()
                 .instance()
-                .bindVariable(FilenameTemplateVariable.TIMESTAMP.name, new StableTimeFormatter(config.getTimestampSource()).apply(record))
+                .bindVariable(FilenameTemplateVariable.TIMESTAMP.name,
+                        new StableTimeFormatter(config.getTimestampSource()).apply(record))
                 .bindVariable(FilenameTemplateVariable.PARTITION.name, () -> record.kafkaPartition().toString())
                 .bindVariable(FilenameTemplateVariable.START_OFFSET.name,
                         parameter -> OldFullKeyFormatters.KAFKA_OFFSET.apply(record, parameter))

--- a/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
+++ b/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import io.aiven.kafka.connect.common.config.StableTimeFormatter;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -167,8 +168,7 @@ public final class S3SinkTask extends SinkTask {
     private String oldFullKey(final SinkRecord record) {
         final var prefix = config.getPrefixTemplate()
                 .instance()
-                .bindVariable(FilenameTemplateVariable.TIMESTAMP.name,
-                        parameter -> OldFullKeyFormatters.timestamp(record, config.getTimestampSource(), parameter))
+                .bindVariable(FilenameTemplateVariable.TIMESTAMP.name, new StableTimeFormatter(config.getTimestampSource()).apply(record))
                 .bindVariable(FilenameTemplateVariable.PARTITION.name, () -> record.kafkaPartition().toString())
                 .bindVariable(FilenameTemplateVariable.START_OFFSET.name,
                         parameter -> OldFullKeyFormatters.KAFKA_OFFSET.apply(record, parameter))

--- a/s3-sink-connector/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
+++ b/s3-sink-connector/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
@@ -33,7 +33,7 @@ import io.aiven.kafka.connect.common.config.FormatType;
 import io.aiven.kafka.connect.common.config.OutputField;
 import io.aiven.kafka.connect.common.config.OutputFieldEncodingType;
 import io.aiven.kafka.connect.common.config.OutputFieldType;
-import io.aiven.kafka.connect.s3.OldFullKeyFormatters;
+import io.aiven.kafka.connect.common.config.StableTimeFormatter;
 import io.aiven.kafka.connect.s3.S3OutputStream;
 
 import com.amazonaws.regions.RegionUtils;
@@ -549,9 +549,9 @@ final class S3SinkConfigTest {
         // null record is fine here, because it's not needed for the wallclock timestamp source
         final var expectedTimestamp = config.getTimestampSource().time(null);
 
-        final var renderedPrefix = config.getPrefixTemplate().instance().bindVariable("timestamp", parameter ->
+        final var renderedPrefix = config.getPrefixTemplate().instance().bindVariable("timestamp",
         // null record is fine here, because it's not needed for the wall clock timestamp source
-        OldFullKeyFormatters.timestamp(null, config.getTimestampSource(), parameter)).render();
+        new StableTimeFormatter(config.getTimestampSource()).apply(null)).render();
 
         assertThat(renderedPrefix)
                 .isEqualTo(String.format("%s/%s/%s/", expectedTimestamp.format(DateTimeFormatter.ofPattern("yyyy")),

--- a/s3-sink-connector/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
+++ b/s3-sink-connector/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
@@ -549,9 +549,12 @@ final class S3SinkConfigTest {
         // null record is fine here, because it's not needed for the wallclock timestamp source
         final var expectedTimestamp = config.getTimestampSource().time(null);
 
-        final var renderedPrefix = config.getPrefixTemplate().instance().bindVariable("timestamp",
-        // null record is fine here, because it's not needed for the wall clock timestamp source
-        new StableTimeFormatter(config.getTimestampSource()).apply(null)).render();
+        final var renderedPrefix = config.getPrefixTemplate()
+                .instance()
+                .bindVariable("timestamp",
+                        // null record is fine here, because it's not needed for the wall clock timestamp source
+                        new StableTimeFormatter(config.getTimestampSource()).apply(null))
+                .render();
 
         assertThat(renderedPrefix)
                 .isEqualTo(String.format("%s/%s/%s/", expectedTimestamp.format(DateTimeFormatter.ofPattern("yyyy")),


### PR DESCRIPTION
with wallclock time (and any other time source that isn't dependents on stable data ) the fields of a formatted timestamp should refer to the same time for the duration of the formatting of the `Template`

This small change ensure that the timestamp is calculated only if any timestamp field is needed, and that same time is used for other fields, so you don't get a weird result form the formatter is `System.currentTimeMillis` changes between calls

it also removes the duplication of the definition of the supported time fields that are supported 