### PR TITLE
[KCON35] : Improvement : Read files with stream instead of loading it all

### DIFF
--- a/s3-source-connector/build.gradle.kts
+++ b/s3-source-connector/build.gradle.kts
@@ -117,7 +117,6 @@ dependencies {
     exclude(group = "org.apache.commons", module = "commons-math3")
     exclude(group = "org.apache.httpcomponents", module = "httpclient")
     exclude(group = "commons-codec", module = "commons-codec")
-    exclude(group = "commons-io", module = "commons-io")
     exclude(group = "commons-net", module = "commons-net")
     exclude(group = "org.eclipse.jetty")
     exclude(group = "org.eclipse.jetty.websocket")

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/Transformer.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/Transformer.java
@@ -17,16 +17,19 @@
 package io.aiven.kafka.connect.s3.source.input;
 
 import java.io.InputStream;
-import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+
+import org.apache.commons.io.function.IOSupplier;
 
 public interface Transformer {
 
     void configureValueConverter(Map<String, String> config, S3SourceConfig s3SourceConfig);
 
-    List<Object> getRecords(InputStream inputStream, String topic, int topicPartition, S3SourceConfig s3SourceConfig);
+    Stream<Object> getRecords(IOSupplier<InputStream> inputStreamIOSupplier, String topic, int topicPartition,
+            S3SourceConfig s3SourceConfig);
 
     byte[] getValueBytes(Object record, String topic, S3SourceConfig s3SourceConfig);
 }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/input/ByteArrayTransformerTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/input/ByteArrayTransformerTest.java
@@ -16,18 +16,17 @@
 
 package io.aiven.kafka.connect.s3.source.input;
 
-import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.EXPECTED_MAX_MESSAGE_BYTES;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 
+import org.apache.commons.io.function.IOSupplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 final class ByteArrayTransformerTest {
 
+    public static final String TEST_TOPIC = "test-topic";
     private ByteArrayTransformer byteArrayTransformer;
 
     @Mock
@@ -51,45 +51,33 @@ final class ByteArrayTransformerTest {
     void testGetRecordsSingleChunk() {
         final byte[] data = { 1, 2, 3, 4, 5 };
         final InputStream inputStream = new ByteArrayInputStream(data);
+        final IOSupplier<InputStream> inputStreamIOSupplier = () -> inputStream;
 
-        when(s3SourceConfig.getInt(EXPECTED_MAX_MESSAGE_BYTES)).thenReturn(10_000); // Larger than data size
+        final Stream<Object> records = byteArrayTransformer.getRecords(inputStreamIOSupplier, TEST_TOPIC, 0,
+                s3SourceConfig);
 
-        final List<Object> records = byteArrayTransformer.getRecords(inputStream, "test-topic", 0, s3SourceConfig);
-
-        assertEquals(1, records.size());
-        assertArrayEquals(data, (byte[]) records.get(0));
+        final List<Object> recs = records.collect(Collectors.toList());
+        assertThat(recs).hasSize(1);
+        assertThat((byte[]) recs.get(0)).isEqualTo(data);
     }
 
     @Test
-    void testGetRecordsMultipleChunks() {
-        final byte[] data = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-        final InputStream inputStream = new ByteArrayInputStream(data);
-
-        when(s3SourceConfig.getInt(EXPECTED_MAX_MESSAGE_BYTES)).thenReturn(5); // Smaller than data size
-
-        final List<Object> records = byteArrayTransformer.getRecords(inputStream, "test-topic", 0, s3SourceConfig);
-
-        assertEquals(2, records.size());
-        assertArrayEquals(new byte[] { 1, 2, 3, 4, 5 }, (byte[]) records.get(0));
-        assertArrayEquals(new byte[] { 6, 7, 8, 9, 10 }, (byte[]) records.get(1));
-    }
-
-    @Test
-    void testGetRecordsEmptyInputStream() throws IOException {
+    void testGetRecordsEmptyInputStream() {
         final InputStream inputStream = new ByteArrayInputStream(new byte[] {});
 
-        when(s3SourceConfig.getInt(EXPECTED_MAX_MESSAGE_BYTES)).thenReturn(5);
+        final IOSupplier<InputStream> inputStreamIOSupplier = () -> inputStream;
 
-        final List<Object> records = byteArrayTransformer.getRecords(inputStream, "test-topic", 0, s3SourceConfig);
+        final Stream<Object> records = byteArrayTransformer.getRecords(inputStreamIOSupplier, TEST_TOPIC, 0,
+                s3SourceConfig);
 
-        assertEquals(0, records.size());
+        assertThat(records).hasSize(0);
     }
 
     @Test
     void testGetValueBytes() {
         final byte[] record = { 1, 2, 3 };
-        final byte[] result = byteArrayTransformer.getValueBytes(record, "test-topic", s3SourceConfig);
+        final byte[] result = byteArrayTransformer.getValueBytes(record, TEST_TOPIC, s3SourceConfig);
 
-        assertArrayEquals(record, result);
+        assertThat(result).containsExactlyInAnyOrder(record);
     }
 }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIteratorTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIteratorTest.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
@@ -78,8 +79,7 @@ final class SourceRecordIteratorTest {
             when(mockS3Client.getObject(anyString(), anyString())).thenReturn(mockS3Object);
             when(mockS3Object.getObjectContent()).thenReturn(mockInputStream);
 
-            when(mockTransformer.getRecords(any(), anyString(), anyInt(), any()))
-                    .thenReturn(Collections.singletonList(new Object()));
+            when(mockTransformer.getRecords(any(), anyString(), anyInt(), any())).thenReturn(Stream.of(new Object()));
 
             final String outStr = "this is a test";
             when(mockTransformer.getValueBytes(any(), anyString(), any()))
@@ -102,7 +102,6 @@ final class SourceRecordIteratorTest {
             assertTrue(iterator.hasNext());
             assertNotNull(iterator.next());
         }
-
     }
 
     private ListObjectsV2Result mockListObjectsResult(final List<S3ObjectSummary> summaries) {


### PR DESCRIPTION
Currently the transformers load the files and get a list of records. This could cause performance issues for large files.
- With Stream/StreamSupport, only when next() is called from iterator, a record is transformed.