### PR TITLE
Utility to extract variables from a rendered template

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/connect/common/templating/Template.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/templating/Template.java
@@ -146,7 +146,7 @@ public final class Template {
     /**
      * Given a template, the {@link Extractor} finds the matching variables from a string.
      *
-     * Where an{@link Instance} generates strings by filling in the variables in a template, the {@link Extractor} does
+     * Where an {@link Instance} generates strings by filling in the variables in a template, the {@link Extractor} does
      * the opposite:
      *
      * <pre>

--- a/commons/src/main/java/io/aiven/kafka/connect/common/templating/Template.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/templating/Template.java
@@ -145,14 +145,14 @@ public final class Template {
 
     /**
      * Given a template, the {@link Extractor} finds the matching variables from a string.
-     *
+     * <p>
      * Where an {@link Instance} generates strings by filling in the variables in a template, the {@link Extractor} does
      * the opposite:
      *
      * <pre>
      * // Renders the string "Hello World!"
      * var tmpl = Template.of("Hello {{name}}!");
-     * var greeting = tmpl.instance().bindVariable("name", () -> "World").render();
+     * var greeting = tmpl.instance().bindVariable("name", () -&gt; "World").render();
      *
      * // The other way around, extracts a name from a string:
      * tmpl.extractor().extract(greeting); // returns a map {name=World}
@@ -204,7 +204,7 @@ public final class Template {
          * @throws IllegalArgumentException
          *             If the input string does not match the template.
          */
-        public Map<String, String> extract(final String input) throws IllegalArgumentException {
+        public Map<String, String> extract(final String input) {
             final Matcher matcher = regex.matcher(input);
             if (!matcher.matches()) {
                 throw new IllegalArgumentException("Input does not match the template");

--- a/commons/src/main/java/io/aiven/kafka/connect/common/templating/Template.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/templating/Template.java
@@ -101,49 +101,6 @@ public final class Template {
         return originalTemplateString;
     }
 
-    public final class Extractor {
-        private final Pattern regex;
-        private final Map<String, String> captureGroups = new HashMap<>();
-
-        private Extractor() {
-            // Build a regex to match the template pattern. Every variable part is mapped to a capturing group
-            // and every text part is quoted to require an exact match. Variable part parameters are ignored.
-            final StringBuilder textAsRegex = new StringBuilder();
-            for (int i = 0; i < templateParts.size(); i++) {
-                if (templateParts.get(i) instanceof TextTemplatePart) {
-                    textAsRegex.append(Pattern.quote(((TextTemplatePart) templateParts.get(i)).getText()));
-                } else if (templateParts.get(i) instanceof VariableTemplatePart) {
-                    final String variableName = ((VariableTemplatePart) templateParts.get(i)).getVariableName();
-                    if (captureGroups.containsKey(variableName)) {
-                        // If the name was already used, we can capture it with a backreference.
-                        textAsRegex.append("\\k<").append(captureGroups.get(variableName)).append('>');
-                    } else {
-                        textAsRegex.append("(?<capture").append(i).append(">.*?)");
-                        // A capturing group cannot contain underscores, so we map every variable name to a valid unique
-                        // name.
-                        captureGroups.put(((VariableTemplatePart) templateParts.get(i)).getVariableName(),
-                                "capture" + i);
-                    }
-                }
-            }
-            regex = Pattern.compile(textAsRegex.toString());
-        }
-
-        public Map<String, String> extract(final String input) {
-            final Matcher matcher = regex.matcher(input);
-            if (!matcher.matches()) {
-                throw new IllegalArgumentException("Input does not match the template");
-            }
-
-            final ImmutableMap.Builder<String, String> found = new ImmutableMap.Builder<>();
-            for (final Map.Entry<String, String> entry : captureGroups.entrySet()) {
-                found.put(entry.getKey(), matcher.group(entry.getValue()));
-            }
-
-            return found.build();
-        }
-    }
-
     public final class Instance {
         private final Map<String, Function<Parameter, String>> bindings = new HashMap<>();
 
@@ -185,4 +142,81 @@ public final class Template {
             return stringBuilder.toString();
         }
     }
+
+    /**
+     * Given a template, the {@link Extractor} finds the matching variables from a string.
+     *
+     * Where an{@link Instance} generates strings by filling in the variables in a template, the {@link Extractor} does
+     * the opposite:
+     *
+     * <pre>
+     * // Renders the string "Hello World!"
+     * var tmpl = Template.of("Hello {{name}}!");
+     * var greeting = tmpl.instance().bindVariable("name", () -> "World").render();
+     *
+     * // The other way around, extracts a name from a string:
+     * tmpl.extractor().extract(greeting); // returns a map {name=World}
+     * tmpl.extractor().extract("Hello everyone!"); // returns a map {name=everyone}
+     * </pre>
+     *
+     * The intention is that applying the map back to the template will yield the original string, but the round-trip is
+     * not always exact.
+     * <ul>
+     * <li>Rendering a string uses a supplier and the extractor returns a fixed string.</li>
+     * <li>Variable parameters are currently ignored (to be determined).</li>
+     * </ul>
+     */
+    public final class Extractor {
+        private final Pattern regex;
+        private final Map<String, String> captureGroups = new HashMap<>();
+
+        private Extractor() {
+            // Build a regex to match the template pattern. Every variable part is mapped to a capturing group
+            // and every text part is quoted to require an exact match. Variable part parameters are ignored.
+            final StringBuilder textAsRegex = new StringBuilder();
+            for (int i = 0; i < templateParts.size(); i++) {
+                if (templateParts.get(i) instanceof TextTemplatePart) {
+                    textAsRegex.append(Pattern.quote(((TextTemplatePart) templateParts.get(i)).getText()));
+                } else if (templateParts.get(i) instanceof VariableTemplatePart) {
+                    final String variableName = ((VariableTemplatePart) templateParts.get(i)).getVariableName();
+                    if (captureGroups.containsKey(variableName)) {
+                        // If the name was already used, we can capture it with a backreference.
+                        textAsRegex.append("\\k<").append(captureGroups.get(variableName)).append('>');
+                    } else {
+                        textAsRegex.append("(?<capture").append(i).append(">.*?)");
+                        // A capturing group cannot contain underscores, so we map every variable name to a valid unique
+                        // name.
+                        captureGroups.put(((VariableTemplatePart) templateParts.get(i)).getVariableName(),
+                                "capture" + i);
+                    }
+                }
+            }
+            regex = Pattern.compile(textAsRegex.toString());
+        }
+
+        /**
+         * Performs the variable extraction from the input string.
+         *
+         * @param input
+         *            A string to extract variables from.
+         * @return An immutable map of key-value pairs extracted from the input string, corresponding to the template
+         *         variable names.
+         * @throws IllegalArgumentException
+         *             If the input string does not match the template.
+         */
+        public Map<String, String> extract(final String input) throws IllegalArgumentException {
+            final Matcher matcher = regex.matcher(input);
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException("Input does not match the template");
+            }
+
+            final ImmutableMap.Builder<String, String> found = new ImmutableMap.Builder<>();
+            for (final Map.Entry<String, String> entry : captureGroups.entrySet()) {
+                found.put(entry.getKey(), matcher.group(entry.getValue()));
+            }
+
+            return found.build();
+        }
+    }
+
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/templating/TemplateParser.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/templating/TemplateParser.java
@@ -30,15 +30,16 @@ public final class TemplateParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TemplateParser.class);
 
-    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{\\{\\s*([\\w]+)?(:?)([\\w=]+)?\\s*}}"); // {{
-                                                                                                                // var:foo=bar
-                                                                                                                // }}
+    /** Matches <code>{{ var:foo=bar }}</code> */
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{\\{\\s*([\\w]+)?(:?)([\\w=]+)?\\s*}}");
 
-    private static final Pattern PARAMETER_PATTERN = Pattern.compile("([\\w]+)?=?([\\w]+)?"); // foo=bar
+    /** Matches <code>foo=bar</code> */
+    private static final Pattern PARAMETER_PATTERN = Pattern.compile("([\\w]+)?=?([\\w]+)?");
 
     private TemplateParser() {
     }
 
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public static Pair<List<Pair<String, VariableTemplatePart.Parameter>>, List<TemplatePart>> parse(
             final String template) {
         LOGGER.debug("Parse template: {}", template);
@@ -50,9 +51,7 @@ public final class TemplateParser {
 
         int position = 0;
         while (matcher.find()) {
-            templatePartsBuilder.add(new TextTemplatePart(template.substring(position, matcher.start())) // NOPMD
-                                                                                                         // AvoidInstantiatingObjectsInLoops
-            );
+            templatePartsBuilder.add(new TextTemplatePart(template.substring(position, matcher.start())));
 
             final String variable = matcher.group(1);
 
@@ -69,8 +68,7 @@ public final class TemplateParser {
 
             final VariableTemplatePart.Parameter parseParameter = parseParameter(variable, parameter);
             variablesAndParametersBuilder.add(Pair.of(variable, parseParameter));
-            templatePartsBuilder.add(new VariableTemplatePart(variable, parseParameter, matcher.group())); // NOPMD
-                                                                                                           // AvoidInstantiatingObjectsInLoops
+            templatePartsBuilder.add(new VariableTemplatePart(variable, parseParameter, matcher.group()));
             position = matcher.end();
         }
         templatePartsBuilder.add(new TextTemplatePart(template.substring(position)));

--- a/commons/src/test/java/io/aiven/kafka/connect/common/templating/TemplateTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/templating/TemplateTest.java
@@ -16,6 +16,9 @@
 
 package io.aiven.kafka.connect.common.templating;
 
+import static io.aiven.kafka.connect.common.templating.TemplateTestUtil.withBindings;
+import static io.aiven.kafka.connect.common.templating.TemplateTestUtil.withInput;
+import static io.aiven.kafka.connect.common.templating.TemplateTestUtil.withNoBindings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -25,27 +28,155 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.stream.Collectors;
 
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
 
+/**
+ * A helper class that can be used to test the rendering and extraction of a template in a fluent way:
+ *
+ * <pre>
+ * // To test that a template renders correctly with the given variables.
+ * assertThat(Template.of("{{foo}}/{{bar}}")).satisfies(rendersTo("FOO/BAR").whenBinding("foo", "FOO", "bar", "BAR"));
+ * </pre>
+ *
+ * <pre>
+ * // To test that a template extracts the expected variables from the given string.
+ * assertThat(Template.of("{{foo}}/{{bar}}")).satisfies(extracts("foo", "FOO", "bar", "BAR").whenGiven("FOO/BAR"));
+ * </pre>
+ */
+class TemplateTestUtil {
+
+    private final String rendered;
+    private final String[] varNameAndValues;
+
+    TemplateTestUtil(final String rendered, final String... varNameAndValues) {
+        assertThat(varNameAndValues.length).as("Must set names and values in pairs").isEven();
+        this.rendered = rendered;
+        this.varNameAndValues = varNameAndValues; // NOPMD ArrayIsStoredDirectly
+    }
+
+    static public TemplateTestUtil withBindings(final String... varNameAndValues) {
+        return new TemplateTestUtil("", varNameAndValues);
+    }
+
+    static public TemplateTestUtil withNoBindings() {
+        return new TemplateTestUtil("");
+    }
+
+    static public TemplateTestUtil withInput(final String rendered) {
+        return new TemplateTestUtil(rendered);
+    }
+
+    Condition<Template> rendersTo(final String rendered) {
+        return new TemplateTestUtil(rendered, this.varNameAndValues).testRender();
+    }
+
+    Condition<Template> extracts(final String... varNameAndValues) {
+        return new TemplateTestUtil(this.rendered, varNameAndValues).testExtract();
+    }
+
+    Condition<Template> extractsEmpty() {
+        return new TemplateTestUtil(this.rendered).testExtract();
+    }
+
+    private Condition<Template> testRender() {
+        return new Condition<>(template -> {
+            final var instance = template.instance();
+            for (int i = 0; i < varNameAndValues.length; i += 2) {
+                final var value = varNameAndValues[i + 1];
+                instance.bindVariable(varNameAndValues[i], () -> value);
+            }
+            assertThat(instance.render()).isEqualTo(rendered);
+            // Failed tests are indicated by assertions, not by this return value.
+            return true;
+        }, "Renders to " + rendered);
+    }
+
+    private Condition<Template> testExtract() {
+        return new Condition<>(template -> {
+            final var extractor = template.extractor();
+            final var extracted = extractor.extract(rendered);
+            final var found = new HashSet<String>();
+            for (int i = 0; i < varNameAndValues.length; i += 2) {
+                assertThat(extracted).containsEntry(varNameAndValues[i], varNameAndValues[i + 1]);
+                found.add(varNameAndValues[i]);
+            }
+            assertThat(extracted).containsOnlyKeys(found);
+            // Failed tests are indicated by assertions, not by this return value.
+            return true;
+        }, "Extracts " + rendered);
+    }
+}
+
 final class TemplateTest {
+
+    /**
+     * Meta-tests to ensure that the test utility detects the errors it claims and fails with meaningful messages.
+     */
+    @Test
+    void testHelper() {
+        // A basic example of a successful test
+        assertThat(Template.of("{{foo}}/{{bar}}"))
+                .satisfies(withBindings("foo", "FOO", "bar", "BAR").rendersTo("FOO/BAR"))
+                .satisfies(withInput("FOO/BAR").extracts("foo", "FOO", "bar", "BAR"));
+
+        // Failure when the test helper is misconfigured.
+        assertThatThrownBy(() -> assertThat(Template.of("{{foo}}/{{bar}}"))
+                .satisfies(withBindings("foo", "FOO", "bar").rendersTo("FOO/BAR"))).isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Must set names and values in pairs")
+                .hasMessageContaining("Expecting 3 to be even");
+
+        // Failure when the instance does not rendered as expected
+        assertThatThrownBy(() -> assertThat(Template.of("{{foo}}/{{bar}}/{{baz}}"))
+                .satisfies(withBindings("foo", "FOO", "bar", "BAR").rendersTo("FOO/bar")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("expected: \"FOO/bar\"")
+                .hasMessageContaining("but was: \"FOO/BAR/{{baz}}\"");
+
+        // Failure when the extractor does not extract as expected
+        assertThatThrownBy(() -> assertThat(Template.of("{{foo}}/{{bar}}"))
+                .satisfies(withInput("FOO/BAR").extracts("foo", "foo", "bar", "bar")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("but the following map entries had different values:")
+                .hasMessageContaining("[\"foo\"=\"FOO\" (expected: \"foo\")]");
+
+        // Failure when an expected variable value is missing
+        assertThatThrownBy(
+                () -> assertThat(Template.of("{{foo}}/{{bar}}")).satisfies(withInput("FOO/BAR").extracts("foo", "FOO")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("to contain only following keys:")
+                .hasMessageContaining("[\"foo\"]");
+
+        // Failure when too many variables are expected in the returned
+        assertThatThrownBy(() -> assertThat(Template.of("{{foo}}/{{bar}}"))
+                .satisfies(withInput("FOO/BAR").extracts("foo", "FOO", "bar", "BAR", "baz", "BAZ")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("but could not find the following map entries:")
+                .hasMessageContaining("[\"baz\"=\"BAZ\"]");
+    }
+
     @Test
     void emptyString() {
-        final Template template = Template.of("");
-        assertThat(template.instance().render()).isEmpty();
+        assertThat(Template.of("")).satisfies(withBindings("foo", "FOO").rendersTo(""))
+                .satisfies(withNoBindings().rendersTo(""))
+                .satisfies(withInput("").extractsEmpty());
     }
 
     @Test
     void noVariables() {
-        final Template template = Template.of("somestring");
-        assertThat(template.instance().render()).isEqualTo("somestring");
+        assertThat(Template.of("somestring")).satisfies(withBindings("foo", "FOO").rendersTo("somestring"))
+                .satisfies(withNoBindings().rendersTo("somestring"))
+                .satisfies(withInput("somestring").extractsEmpty());
     }
 
     @Test
     void newLine() {
-        final Template template = Template.of("some\nstring");
-        assertThat(template.instance().render()).isEqualTo("some\nstring");
+        assertThat(Template.of("some\nstring")).satisfies(withBindings("foo", "FOO").rendersTo("some\nstring"))
+                .satisfies(withNoBindings().rendersTo("some\nstring"))
+                .satisfies(withInput("some\nstring").extractsEmpty());
     }
 
     @Test
@@ -57,53 +188,46 @@ final class TemplateTest {
 
     @Test
     void variableFormatNoSpaces() {
-        final Template template = Template.of("{{foo}}");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        assertThat(instance.render()).isEqualTo("foo");
+        assertThat(Template.of("{{foo}}")).satisfies(withBindings("foo", "FOO").rendersTo("FOO"))
+                .satisfies(withInput("FOO").extracts("foo", "FOO"));
     }
 
     @Test
     void variableFormatLeftSpace() {
-        final Template template = Template.of("{{ foo}}");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        assertThat(instance.render()).isEqualTo("foo");
+        assertThat(Template.of("{{ foo}}")).satisfies(withBindings("foo", "FOO").rendersTo("FOO"))
+                .satisfies(withInput("FOO").extracts("foo", "FOO"));
     }
 
     @Test
     void variableFormatRightSpace() {
-        final Template template = Template.of("{{foo }}");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        assertThat(instance.render()).isEqualTo("foo");
+        assertThat(Template.of("{{foo }}")).satisfies(withBindings("foo", "FOO").rendersTo("FOO"))
+                .satisfies(withInput("FOO").extracts("foo", "FOO"));
     }
 
     @Test
     void variableFormatBothSpaces() {
-        final Template template = Template.of("{{ foo }}");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        assertThat(instance.render()).isEqualTo("foo");
+        assertThat(Template.of("{{ foo }}")).satisfies(withBindings("foo", "FOO").rendersTo("FOO"))
+                .satisfies(withInput("FOO").extracts("foo", "FOO"));
     }
 
     @Test
     void variableFormatBothSpacesWithVariable() {
-        final Template template = Template.of("{{ foo:tt=true }}");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        assertThat(instance.render()).isEqualTo("foo");
+        assertThat(Template.of("{{ foo:tt=true }}")).satisfies(withBindings("foo", "FOO").rendersTo("FOO"))
+                .satisfies(withInput("FOO").extracts("foo", "FOO"));
     }
 
     @Test
     void parseVariableWithParameter() {
-        final String render = Template.of("{{foo:tt=true}}").instance().bindVariable("foo", parameter -> {
+        final Template template = Template.of("{{ foo:tt=true }}");
+        final String render = template.instance().bindVariable("foo", parameter -> {
             assertThat(parameter.getName()).isEqualTo("tt");
             assertThat(parameter.getValue()).isEqualTo("true");
             assertThat(parameter.asBoolean()).isTrue();
-            return "";
+            return "PARAMETER_TESTED";
         }).render();
-        assertThat(render).isEmpty();
+
+        assertThat(render).isEqualTo("PARAMETER_TESTED");
+        assertThat(template).satisfies(withInput("FOO").extracts("foo", "FOO"));
     }
 
     @Test
@@ -132,92 +256,73 @@ final class TemplateTest {
 
     @Test
     void variableFormatMultipleSpaces() {
-        final Template template = Template.of("{{   foo  }}");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        assertThat(instance.render()).isEqualTo("foo");
+        assertThat(Template.of("{{   foo  }}")).satisfies(withBindings("foo", "FOO").rendersTo("FOO"))
+                .satisfies(withInput("FOO").extracts("foo", "FOO"));
     }
 
     @Test
     void variableFormatTabs() {
-        final Template template = Template.of("{{\tfoo\t}}");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        assertThat(instance.render()).isEqualTo("foo");
+        assertThat(Template.of("{{\tfoo\t}}")).satisfies(withBindings("foo", "FOO").rendersTo("FOO"))
+                .satisfies(withInput("FOO").extracts("foo", "FOO"));
     }
 
     @Test
     void variableUnderscoreAlone() {
-        final Template template = Template.of("{{ _ }}");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("_", () -> "foo");
-        assertThat(instance.render()).isEqualTo("foo");
+        assertThat(Template.of("{{ _ }}")).satisfies(withBindings("_", "FOO").rendersTo("FOO"))
+                .satisfies(withInput("FOO").extracts("_", "FOO"));
     }
 
     @Test
     void variableUnderscoreWithOtherSymbols() {
-        final Template template = Template.of("{{ foo_bar }}");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo_bar", () -> "foo_bar");
-        assertThat(instance.render()).isEqualTo("foo_bar");
+        assertThat(Template.of("{{ foo_bar }}")).satisfies(withBindings("foo_bar", "FOO_BAR").rendersTo("FOO_BAR"))
+                .satisfies(withInput("FOO_BAR").extracts("foo_bar", "FOO_BAR"));
     }
 
     @Test
     void placeholderHasCurlyBracesInside() {
         final String templateStr = "{{ { }}";
-        final Template template = Template.of(templateStr);
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("{", () -> "foo");
-        assertThat(instance.render()).isEqualTo(templateStr);
+        assertThat(Template.of(templateStr)).satisfies(withBindings("{", "FOO").rendersTo(templateStr))
+                .satisfies(withInput(templateStr).extractsEmpty());
     }
 
     @Test
     void unclosedPlaceholder() {
         final String templateStr = "bb {{ aaa ";
-        final Template template = Template.of(templateStr);
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("aaa", () -> "foo");
-        assertThat(instance.render()).isEqualTo(templateStr);
+        assertThat(Template.of(templateStr)).satisfies(withBindings("aaa", "FOO").rendersTo(templateStr))
+                .satisfies(withInput(templateStr).extractsEmpty());
     }
 
     @Test
     void variableInBeginning() {
-        final Template template = Template.of("{{ foo }} END");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        assertThat(instance.render()).isEqualTo("foo END");
+        assertThat(Template.of("{{ foo }} END")).satisfies(withBindings("foo", "FOO").rendersTo("FOO END"))
+                .satisfies(withInput("FOO END").extracts("foo", "FOO"));
     }
 
     @Test
     void variableInMiddle() {
-        final Template template = Template.of("BEGINNING {{ foo }} END");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        assertThat(instance.render()).isEqualTo("BEGINNING foo END");
+        assertThat(Template.of("BEGINNING {{ foo }} END"))
+                .satisfies(withBindings("foo", "FOO").rendersTo("BEGINNING FOO END"))
+                .satisfies(withInput("BEGINNING FOO END").extracts("foo", "FOO"));
     }
 
     @Test
     void variableInEnd() {
-        final Template template = Template.of("BEGINNING {{ foo }}");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        assertThat(instance.render()).isEqualTo("BEGINNING foo");
+        assertThat(Template.of("BEGINNING {{ foo }}")).satisfies(withBindings("foo", "FOO").rendersTo("BEGINNING FOO"))
+                .satisfies(withInput("BEGINNING FOO").extracts("foo", "FOO"));
     }
 
     @Test
     void nonBoundVariable() {
-        final Template template = Template.of("BEGINNING {{ foo }}");
-        assertThat(template.instance().render()).isEqualTo("BEGINNING {{ foo }}");
+        // Note that the round trip is not completely reversible for unbound variables.
+        assertThat(Template.of("BEGINNING {{ foo }}")).satisfies(withNoBindings().rendersTo("BEGINNING {{ foo }}"))
+                .satisfies(withInput("BEGINNING {{ foo }}").extracts("foo", "{{ foo }}"));
     }
 
     @Test
     void multipleVariables() {
-        final Template template = Template.of("1{{foo}}2{{bar}}3{{baz}}4");
-        final Template.Instance instance = template.instance();
-        instance.bindVariable("foo", () -> "foo");
-        instance.bindVariable("bar", () -> "bar");
-        instance.bindVariable("baz", () -> "baz");
-        assertThat(instance.render()).isEqualTo("1foo2bar3baz4");
+        assertThat(Template.of("1{{foo}}2{{bar}}3{{baz}}4"))
+                .satisfies(withBindings("foo", "FOO", "bar", "BAR", "baz", "BAZ").rendersTo("1FOO2BAR3BAZ4"))
+                .satisfies(withInput("1FOO2BAR3BAZ4").extracts("foo", "FOO", "bar", "BAR", "baz", "BAZ"));
     }
 
     @Test
@@ -226,34 +331,30 @@ final class TemplateTest {
         final Template.Instance instance = template.instance();
         instance.bindVariable("foo", () -> "foo");
         assertThat(instance.render()).isEqualTo("foofoofoo");
+        assertThat(template.extractor().extract("foofoofoo")).hasSize(1).containsEntry("foo", "foo");
     }
 
     @Test
     void bigListOfNaughtyStringsJustString() throws IOException {
         for (final String line : getBigListOfNaughtyStrings()) {
-            final Template template = Template.of(line);
-            final Template.Instance instance = template.instance();
-            assertThat(instance.render()).isEqualTo(line);
+            assertThat(Template.of(line)).satisfies(withNoBindings().rendersTo(line))
+                    .satisfies(withInput(line).extractsEmpty());
         }
     }
 
     @Test
     void bigListOfNaughtyStringsWithVariableInBeginning() throws IOException {
         for (final String line : getBigListOfNaughtyStrings()) {
-            final Template template = Template.of("{{ foo }}" + line);
-            final Template.Instance instance = template.instance();
-            instance.bindVariable("foo", () -> "foo");
-            assertThat(instance.render()).isEqualTo("foo" + line);
+            assertThat(Template.of("{{ foo }}" + line)).satisfies(withBindings("foo", "FOO").rendersTo("FOO" + line))
+                    .satisfies(withInput("FOO" + line).extracts("foo", "FOO"));
         }
     }
 
     @Test
     void bigListOfNaughtyStringsWithVariableInEnd() throws IOException {
         for (final String line : getBigListOfNaughtyStrings()) {
-            final Template template = Template.of(line + "{{ foo }}");
-            final Template.Instance instance = template.instance();
-            instance.bindVariable("foo", () -> "foo");
-            assertThat(instance.render()).isEqualTo(line + "foo");
+            assertThat(Template.of(line + "{{ foo }}")).satisfies(withBindings("foo", "FOO").rendersTo(line + "FOO"))
+                    .satisfies(withInput(line + "FOO").extracts("foo", "FOO"));
         }
     }
 
@@ -261,7 +362,6 @@ final class TemplateTest {
         try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("blns.txt");
                 InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
                 BufferedReader bufferedReader = new BufferedReader(reader)) {
-
             return bufferedReader.lines().filter(s -> !s.isEmpty() && !s.startsWith("#")).collect(Collectors.toList());
         }
     }


### PR DESCRIPTION
The Template class is a simple class to render strings from given variables.  This tool adds the ability to take a rendered string and extract the variables that were used with the template.

Added a AssertJ-style `TemplateTestUtil` to simply testing round-trips where strings are rendered, followed by extracting the variables.

https://aiven.atlassian.net/browse/KCON-1