### PR TITLE
Skip records if already processed [KCON-36]

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/connect/common/source/input/JsonTransformer.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/source/input/JsonTransformer.java
@@ -51,8 +51,8 @@ public class JsonTransformer implements Transformer {
 
     @Override
     public Stream<Object> getRecords(final IOSupplier<InputStream> inputStreamIOSupplier, final String topic,
-            final int topicPartition, final AbstractConfig sourceConfig) {
-        return readJsonRecordsAsStream(inputStreamIOSupplier);
+            final int topicPartition, final AbstractConfig sourceConfig, final long skipRecords) {
+        return readJsonRecordsAsStream(inputStreamIOSupplier, skipRecords);
     }
 
     @Override
@@ -65,7 +65,8 @@ public class JsonTransformer implements Transformer {
         }
     }
 
-    private Stream<Object> readJsonRecordsAsStream(final IOSupplier<InputStream> inputStreamIOSupplier) {
+    private Stream<Object> readJsonRecordsAsStream(final IOSupplier<InputStream> inputStreamIOSupplier,
+            final long skipRecords) {
         // Use a Stream that lazily processes each line as a JSON object
         CustomSpliterator customSpliteratorParam;
         try {
@@ -80,7 +81,7 @@ public class JsonTransformer implements Transformer {
             } catch (IOException e) {
                 LOGGER.error("Error closing BufferedReader: {}", e.getMessage(), e);
             }
-        });
+        }).skip(skipRecords);
     }
 
     /*

--- a/commons/src/main/java/io/aiven/kafka/connect/common/source/input/ParquetTransformer.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/source/input/ParquetTransformer.java
@@ -55,8 +55,8 @@ public class ParquetTransformer implements Transformer {
 
     @Override
     public Stream<Object> getRecords(final IOSupplier<InputStream> inputStreamIOSupplier, final String topic,
-            final int topicPartition, final AbstractConfig sourceConfig) {
-        return getParquetStreamRecords(inputStreamIOSupplier, topic, topicPartition);
+            final int topicPartition, final AbstractConfig sourceConfig, final long skipRecords) {
+        return getParquetStreamRecords(inputStreamIOSupplier, topic, topicPartition, skipRecords);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class ParquetTransformer implements Transformer {
     }
 
     private Stream<Object> getParquetStreamRecords(final IOSupplier<InputStream> inputStreamIOSupplier,
-            final String topic, final int topicPartition) {
+            final String topic, final int topicPartition, final long skipRecords) {
         final String timestamp = String.valueOf(Instant.now().toEpochMilli());
         File parquetFile;
 
@@ -105,7 +105,7 @@ public class ParquetTransformer implements Transformer {
                         return false;
                     }
                 }
-            }, false).onClose(() -> {
+            }, false).skip(skipRecords).onClose(() -> {
                 try {
                     parquetReader.close(); // Ensure reader is closed when the stream is closed
                 } catch (IOException e) {

--- a/commons/src/main/java/io/aiven/kafka/connect/common/source/input/Transformer.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/source/input/Transformer.java
@@ -29,7 +29,7 @@ public interface Transformer {
     void configureValueConverter(Map<String, String> config, AbstractConfig sourceConfig);
 
     Stream<Object> getRecords(IOSupplier<InputStream> inputStreamIOSupplier, String topic, int topicPartition,
-            AbstractConfig sourceConfig);
+            AbstractConfig sourceConfig, long skipRecords);
 
     byte[] getValueBytes(Object record, String topic, AbstractConfig sourceConfig);
 }

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/input/ByteArrayTransformerTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/input/ByteArrayTransformerTest.java
@@ -54,7 +54,7 @@ final class ByteArrayTransformerTest {
         final IOSupplier<InputStream> inputStreamIOSupplier = () -> inputStream;
 
         final Stream<Object> records = byteArrayTransformer.getRecords(inputStreamIOSupplier, TEST_TOPIC, 0,
-                sourceCommonConfig);
+                sourceCommonConfig, 0);
 
         final List<Object> recs = records.collect(Collectors.toList());
         assertThat(recs).hasSize(1);
@@ -68,7 +68,7 @@ final class ByteArrayTransformerTest {
         final IOSupplier<InputStream> inputStreamIOSupplier = () -> inputStream;
 
         final Stream<Object> records = byteArrayTransformer.getRecords(inputStreamIOSupplier, TEST_TOPIC, 0,
-                sourceCommonConfig);
+                sourceCommonConfig, 0);
 
         assertThat(records).hasSize(0);
     }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/OffsetManager.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/OffsetManager.java
@@ -85,18 +85,11 @@ public class OffsetManager {
         return OBJECT_KEY + SEPARATOR + currentObjectKey;
     }
 
-    public boolean shouldSkipRecord(final Map<String, Object> partitionMap, final String currentObjectKey,
-            final long numOfProcessedRecs) {
+    public long recordsProcessedForObjectKey(final Map<String, Object> partitionMap, final String currentObjectKey) {
         if (offsets.containsKey(partitionMap)) {
-            final Map<String, Object> offsetVal = offsets.get(partitionMap);
-            final String objectMapKey = getObjectMapKey(currentObjectKey);
-
-            if (offsetVal.containsKey(objectMapKey)) {
-                final long offsetValue = (long) offsetVal.get(objectMapKey);
-                return numOfProcessedRecs <= offsetValue;
-            }
+            return (long) offsets.get(partitionMap).getOrDefault(getObjectMapKey(currentObjectKey), 0L);
         }
-        return false;
+        return 0L;
     }
 
     public void createNewOffsetMap(final Map<String, Object> partitionMap, final String objectKey,


### PR DESCRIPTION
KCON-36

If a certain number of records are already processed in a file during dr, do not re process those records.
Number of processed recs are already stored in offset storage. Retrieve that and skip in the stream.