### PR TITLE
Source Record Iterator

### DIFF
--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
   implementation(logginglibs.slf4j)
 
   implementation(apache.commons.text)
+  implementation(apache.commons.collection4)
 
   implementation(apache.parquet.avro) {
     exclude(group = "org.xerial.snappy", module = "snappy-java")

--- a/s3-source-connector/build.gradle.kts
+++ b/s3-source-connector/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
   compileOnly(apache.kafka.connect.runtime)
 
   implementation(project(":commons"))
+  implementation(apache.commons.collection4)
   implementation("com.amazonaws:aws-java-sdk-s3:$amazonS3Version")
   implementation("com.amazonaws:aws-java-sdk-sts:$amazonSTSVersion")
 

--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationTest.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationTest.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.connect.s3.source;
 
+import static io.aiven.kafka.connect.common.source.offsets.OffsetManager.SEPARATOR;
 import static io.aiven.kafka.connect.s3.source.S3SourceTask.OBJECT_KEY;
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.AWS_ACCESS_KEY_ID_CONFIG;
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.AWS_S3_BUCKET_NAME_CONFIG;
@@ -28,7 +29,6 @@ import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.TARGET_TOPI
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.TARGET_TOPIC_PARTITIONS;
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.VALUE_CONVERTER_SCHEMA_REGISTRY_URL;
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.VALUE_SERIALIZER;
-import static io.aiven.kafka.connect.s3.source.utils.OffsetManager.SEPARATOR;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceTask.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceTask.java
@@ -186,8 +186,9 @@ public class S3SourceTask extends SourceTask {
         if (connectorStopped.get()) {
             return results;
         }
+        // TODO pull RecordProcessor.processRecords into this class.
         return RecordProcessor.processRecords(sourceRecordIterator, results, s3SourceConfig, keyConverter,
-                valueConverter, connectorStopped, this.transformer, fileReader, offsetManager);
+                valueConverter, connectorStopped);
     }
 
     private void waitForObjects() throws InterruptedException {

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceTask.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceTask.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.aiven.kafka.connect.s3.source.utils.S3OffsetManagerEntry;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -43,6 +42,7 @@ import io.aiven.kafka.connect.s3.source.input.TransformerFactory;
 import io.aiven.kafka.connect.s3.source.utils.FileReader;
 import io.aiven.kafka.connect.s3.source.utils.OffsetManager;
 import io.aiven.kafka.connect.s3.source.utils.RecordProcessor;
+import io.aiven.kafka.connect.s3.source.utils.S3OffsetManagerEntry;
 import io.aiven.kafka.connect.s3.source.utils.S3SourceRecord;
 import io.aiven.kafka.connect.s3.source.utils.SourceRecordIterator;
 import io.aiven.kafka.connect.s3.source.utils.Version;
@@ -67,7 +67,7 @@ public class S3SourceTask extends SourceTask {
     @Deprecated
     public static final String BUCKET = S3OffsetManagerEntry.BUCKET;
     /**
-     * @deprecated use {@link S3OffsetManagerEntry#<></>}.
+     * @deprecated use {@link S3OffsetManagerEntry#TOPIC}.
      */
     @Deprecated
     public static final String TOPIC = S3OffsetManagerEntry.TOPIC;
@@ -125,7 +125,7 @@ public class S3SourceTask extends SourceTask {
         initializeS3Client();
         transformer = TransformerFactory.getTransformer(s3SourceConfig);
         offsetManager = new OffsetManager(context, s3SourceConfig);
-        String s3Bucket = s3SourceConfig.getString(AWS_S3_BUCKET_NAME_CONFIG);
+        final String s3Bucket = s3SourceConfig.getString(AWS_S3_BUCKET_NAME_CONFIG);
         fileReader = new FileReader(s3SourceConfig, s3Bucket, failedObjectKeys);
         prepareReaderFromOffsetStorageReader();
         this.taskInitialized = true;

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceTask.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceTask.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.aiven.kafka.connect.s3.source.utils.S3OffsetManagerEntry;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -60,11 +61,27 @@ public class S3SourceTask extends SourceTask {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3SourceTask.class);
 
-    public static final String BUCKET = "bucket";
-    public static final String TOPIC = "topic";
+    /**
+     * @deprecated use {@link S3OffsetManagerEntry#BUCKET}.
+     */
+    @Deprecated
+    public static final String BUCKET = S3OffsetManagerEntry.BUCKET;
+    /**
+     * @deprecated use {@link S3OffsetManagerEntry#<></>}.
+     */
+    @Deprecated
+    public static final String TOPIC = S3OffsetManagerEntry.TOPIC;
 
-    public static final String OBJECT_KEY = "object_key";
-    public static final String PARTITION = "topicPartition";
+    /**
+     * @deprecated use {@link S3OffsetManagerEntry#OBJECT_KEY}.
+     */
+    @Deprecated
+    public static final String OBJECT_KEY = S3OffsetManagerEntry.OBJECT_KEY;
+    /**
+     * @deprecated use {@link S3OffsetManagerEntry#PARTITION}.
+     */
+    @Deprecated
+    public static final String PARTITION = S3OffsetManagerEntry.PARTITION;
 
     private static final long S_3_POLL_INTERVAL_MS = 10_000L;
     private static final long ERROR_BACKOFF = 1000L;
@@ -79,8 +96,6 @@ public class S3SourceTask extends SourceTask {
 
     private Transformer transformer;
 
-    private String s3Bucket;
-
     private boolean taskInitialized;
 
     private final AtomicBoolean connectorStopped = new AtomicBoolean();
@@ -89,7 +104,6 @@ public class S3SourceTask extends SourceTask {
     private final Object pollLock = new Object();
     private FileReader fileReader;
     private final Set<String> failedObjectKeys = new HashSet<>();
-    private final Set<String> inProcessObjectKeys = new HashSet<>();
 
     private OffsetManager offsetManager;
 
@@ -109,10 +123,10 @@ public class S3SourceTask extends SourceTask {
         s3SourceConfig = new S3SourceConfig(props);
         initializeConverters();
         initializeS3Client();
-        this.s3Bucket = s3SourceConfig.getString(AWS_S3_BUCKET_NAME_CONFIG);
-        this.transformer = TransformerFactory.getTransformer(s3SourceConfig);
+        transformer = TransformerFactory.getTransformer(s3SourceConfig);
         offsetManager = new OffsetManager(context, s3SourceConfig);
-        fileReader = new FileReader(s3SourceConfig, this.s3Bucket, failedObjectKeys);
+        String s3Bucket = s3SourceConfig.getString(AWS_S3_BUCKET_NAME_CONFIG);
+        fileReader = new FileReader(s3SourceConfig, s3Bucket, failedObjectKeys);
         prepareReaderFromOffsetStorageReader();
         this.taskInitialized = true;
     }
@@ -213,23 +227,23 @@ public class S3SourceTask extends SourceTask {
     }
 
     // below for visibility in tests
-    public Optional<Converter> getKeyConverter() {
+    Optional<Converter> getKeyConverter() {
         return keyConverter;
     }
 
-    public Converter getValueConverter() {
+    Converter getValueConverter() {
         return valueConverter;
     }
 
-    public Transformer getTransformer() {
+    Transformer getTransformer() {
         return transformer;
     }
 
-    public boolean isTaskInitialized() {
+    boolean isTaskInitialized() {
         return taskInitialized;
     }
 
-    public AtomicBoolean getConnectorStopped() {
+    AtomicBoolean getConnectorStopped() {
         return new AtomicBoolean(connectorStopped.get());
     }
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceTask.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceTask.java
@@ -138,8 +138,8 @@ public class S3SourceTask extends SourceTask {
     }
 
     private void prepareReaderFromOffsetStorageReader() {
-        sourceRecordIterator = new SourceRecordIterator(s3SourceConfig, s3Client, this.s3Bucket, offsetManager,
-                this.transformer, fileReader);
+        sourceRecordIterator = new SourceRecordIterator(s3SourceConfig, s3Client, offsetManager, this.transformer,
+                fileReader.fetchObjectSummaries(s3Client));
     }
 
     @Override

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceTask.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceTask.java
@@ -35,13 +35,14 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.storage.Converter;
 
+import io.aiven.kafka.connect.common.source.offsets.OffsetManager;
 import io.aiven.kafka.connect.s3.source.config.S3ClientFactory;
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 import io.aiven.kafka.connect.s3.source.input.TransformerFactory;
 import io.aiven.kafka.connect.s3.source.utils.FileReader;
-import io.aiven.kafka.connect.s3.source.utils.OffsetManager;
 import io.aiven.kafka.connect.s3.source.utils.RecordProcessor;
+import io.aiven.kafka.connect.s3.source.utils.S3OffsetManager;
 import io.aiven.kafka.connect.s3.source.utils.S3OffsetManagerEntry;
 import io.aiven.kafka.connect.s3.source.utils.S3SourceRecord;
 import io.aiven.kafka.connect.s3.source.utils.SourceRecordIterator;
@@ -124,7 +125,7 @@ public class S3SourceTask extends SourceTask {
         initializeConverters();
         initializeS3Client();
         transformer = TransformerFactory.getTransformer(s3SourceConfig);
-        offsetManager = new OffsetManager(context, s3SourceConfig);
+        offsetManager = new S3OffsetManager(context, s3SourceConfig);
         final String s3Bucket = s3SourceConfig.getString(AWS_S3_BUCKET_NAME_CONFIG);
         fileReader = new FileReader(s3SourceConfig, s3Bucket, failedObjectKeys);
         prepareReaderFromOffsetStorageReader();

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/AvroTransformer.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/AvroTransformer.java
@@ -29,7 +29,7 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+import org.apache.kafka.common.config.AbstractConfig;
 
 import com.amazonaws.util.IOUtils;
 import org.apache.avro.file.DataFileReader;
@@ -47,21 +47,21 @@ public class AvroTransformer implements Transformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(AvroTransformer.class);
 
     @Override
-    public void configureValueConverter(final Map<String, String> config, final S3SourceConfig s3SourceConfig) {
-        config.put(SCHEMA_REGISTRY_URL, s3SourceConfig.getString(SCHEMA_REGISTRY_URL));
+    public void configureValueConverter(final Map<String, String> config, final AbstractConfig sourceConfig) {
+        config.put(SCHEMA_REGISTRY_URL, sourceConfig.getString(SCHEMA_REGISTRY_URL));
     }
 
     @Override
     public Stream<Object> getRecords(final IOSupplier<InputStream> inputStreamIOSupplier, final String topic,
-            final int topicPartition, final S3SourceConfig s3SourceConfig) {
+            final int topicPartition, final AbstractConfig sourceConfig) {
         final DatumReader<GenericRecord> datumReader = new GenericDatumReader<>();
         return readAvroRecordsAsStream(inputStreamIOSupplier, datumReader);
     }
 
     @Override
-    public byte[] getValueBytes(final Object record, final String topic, final S3SourceConfig s3SourceConfig) {
+    public byte[] getValueBytes(final Object record, final String topic, final AbstractConfig sourceConfig) {
         return TransformationUtils.serializeAvroRecordToBytes(Collections.singletonList((GenericRecord) record), topic,
-                s3SourceConfig);
+                sourceConfig);
     }
 
     private Stream<Object> readAvroRecordsAsStream(final IOSupplier<InputStream> inputStreamIOSupplier,

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/ByteArrayTransformer.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/ByteArrayTransformer.java
@@ -24,7 +24,7 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+import org.apache.kafka.common.config.AbstractConfig;
 
 import org.apache.commons.io.function.IOSupplier;
 import org.slf4j.Logger;
@@ -34,13 +34,13 @@ public class ByteArrayTransformer implements Transformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ByteArrayTransformer.class);
 
     @Override
-    public void configureValueConverter(final Map<String, String> config, final S3SourceConfig s3SourceConfig) {
+    public void configureValueConverter(final Map<String, String> config, final AbstractConfig sourceConfig) {
         // For byte array transformations, ByteArrayConverter is the converter which is the default config.
     }
 
     @Override
     public Stream<Object> getRecords(final IOSupplier<InputStream> inputStreamIOSupplier, final String topic,
-            final int topicPartition, final S3SourceConfig s3SourceConfig) {
+            final int topicPartition, final AbstractConfig sourceConfig) {
 
         // Create a Stream that processes each chunk lazily
         return StreamSupport.stream(new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
@@ -66,7 +66,7 @@ public class ByteArrayTransformer implements Transformer {
     }
 
     @Override
-    public byte[] getValueBytes(final Object record, final String topic, final S3SourceConfig s3SourceConfig) {
+    public byte[] getValueBytes(final Object record, final String topic, final AbstractConfig sourceConfig) {
         return (byte[]) record;
     }
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/JsonTransformer.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/JsonTransformer.java
@@ -29,7 +29,7 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+import org.apache.kafka.common.config.AbstractConfig;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -45,18 +45,18 @@ public class JsonTransformer implements Transformer {
     final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
-    public void configureValueConverter(final Map<String, String> config, final S3SourceConfig s3SourceConfig) {
+    public void configureValueConverter(final Map<String, String> config, final AbstractConfig sourceConfig) {
         config.put(SCHEMAS_ENABLE, "false");
     }
 
     @Override
     public Stream<Object> getRecords(final IOSupplier<InputStream> inputStreamIOSupplier, final String topic,
-            final int topicPartition, final S3SourceConfig s3SourceConfig) {
+            final int topicPartition, final AbstractConfig sourceConfig) {
         return readJsonRecordsAsStream(inputStreamIOSupplier);
     }
 
     @Override
-    public byte[] getValueBytes(final Object record, final String topic, final S3SourceConfig s3SourceConfig) {
+    public byte[] getValueBytes(final Object record, final String topic, final AbstractConfig sourceConfig) {
         try {
             return objectMapper.writeValueAsBytes(record);
         } catch (JsonProcessingException e) {

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/ParquetTransformer.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/ParquetTransformer.java
@@ -32,7 +32,7 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+import org.apache.kafka.common.config.AbstractConfig;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.compress.utils.IOUtils;
@@ -48,20 +48,20 @@ public class ParquetTransformer implements Transformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ParquetTransformer.class);
 
     @Override
-    public void configureValueConverter(final Map<String, String> config, final S3SourceConfig s3SourceConfig) {
-        config.put(SCHEMA_REGISTRY_URL, s3SourceConfig.getString(SCHEMA_REGISTRY_URL));
+    public void configureValueConverter(final Map<String, String> config, final AbstractConfig sourceConfig) {
+        config.put(SCHEMA_REGISTRY_URL, sourceConfig.getString(SCHEMA_REGISTRY_URL));
     }
 
     @Override
     public Stream<Object> getRecords(final IOSupplier<InputStream> inputStreamIOSupplier, final String topic,
-            final int topicPartition, final S3SourceConfig s3SourceConfig) {
+            final int topicPartition, final AbstractConfig sourceConfig) {
         return getParquetStreamRecords(inputStreamIOSupplier, topic, topicPartition);
     }
 
     @Override
-    public byte[] getValueBytes(final Object record, final String topic, final S3SourceConfig s3SourceConfig) {
+    public byte[] getValueBytes(final Object record, final String topic, final AbstractConfig sourceConfig) {
         return TransformationUtils.serializeAvroRecordToBytes(Collections.singletonList((GenericRecord) record), topic,
-                s3SourceConfig);
+                sourceConfig);
     }
 
     private Stream<Object> getParquetStreamRecords(final IOSupplier<InputStream> inputStreamIOSupplier,

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/TransformationUtils.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/TransformationUtils.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+import org.apache.kafka.common.config.AbstractConfig;
 
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import org.apache.avro.generic.GenericRecord;
@@ -41,11 +41,11 @@ final public class TransformationUtils {
     }
 
     static byte[] serializeAvroRecordToBytes(final List<GenericRecord> avroRecords, final String topic,
-            final S3SourceConfig s3SourceConfig) {
+            final AbstractConfig sourceConfig) {
         final Map<String, String> config = Collections.singletonMap(SCHEMA_REGISTRY_URL,
-                s3SourceConfig.getString(SCHEMA_REGISTRY_URL));
+                sourceConfig.getString(SCHEMA_REGISTRY_URL));
 
-        try (KafkaAvroSerializer avroSerializer = (KafkaAvroSerializer) s3SourceConfig.getClass(VALUE_SERIALIZER)
+        try (KafkaAvroSerializer avroSerializer = (KafkaAvroSerializer) sourceConfig.getClass(VALUE_SERIALIZER)
                 .getDeclaredConstructor()
                 .newInstance(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             avroSerializer.configure(config, false);

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/Transformer.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/Transformer.java
@@ -33,6 +33,5 @@ public interface Transformer {
     Stream<Object> getRecords(IOSupplier<InputStream> inputStreamIOSupplier, String topic, int topicPartition,
             S3SourceConfig s3SourceConfig);
 
-
     byte[] getValueBytes(Object record, String topic, S3SourceConfig s3SourceConfig);
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/Transformer.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/Transformer.java
@@ -26,10 +26,13 @@ import org.apache.commons.io.function.IOSupplier;
 
 public interface Transformer {
 
+    // TODO make this method accept an S3OffsetManagerEntry and update the values in the configuration directly.
     void configureValueConverter(Map<String, String> config, S3SourceConfig s3SourceConfig);
 
+    // TODO make this method accept an S3OffsetManagerEntry to retrieve the topic an topicParitiion.
     Stream<Object> getRecords(IOSupplier<InputStream> inputStreamIOSupplier, String topic, int topicPartition,
             S3SourceConfig s3SourceConfig);
+
 
     byte[] getValueBytes(Object record, String topic, S3SourceConfig s3SourceConfig);
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/Transformer.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/Transformer.java
@@ -20,18 +20,18 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+import org.apache.kafka.common.config.AbstractConfig;
 
 import org.apache.commons.io.function.IOSupplier;
 
 public interface Transformer {
 
     // TODO make this method accept an S3OffsetManagerEntry and update the values in the configuration directly.
-    void configureValueConverter(Map<String, String> config, S3SourceConfig s3SourceConfig);
+    void configureValueConverter(Map<String, String> config, AbstractConfig sourceConfig);
 
     // TODO make this method accept an S3OffsetManagerEntry to retrieve the topic an topicParitiion.
     Stream<Object> getRecords(IOSupplier<InputStream> inputStreamIOSupplier, String topic, int topicPartition,
-            S3SourceConfig s3SourceConfig);
+            AbstractConfig sourceConfig);
 
-    byte[] getValueBytes(Object record, String topic, S3SourceConfig s3SourceConfig);
+    byte[] getValueBytes(Object record, String topic, AbstractConfig sourceConfig);
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/FileReader.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/FileReader.java
@@ -45,7 +45,7 @@ public class FileReader {
         this.failedObjectKeys = new HashSet<>(failedObjectKeys);
     }
 
-    Iterator<S3ObjectSummary> fetchObjectSummaries(final AmazonS3 s3Client) {
+    public Iterator<S3ObjectSummary> fetchObjectSummaries(final AmazonS3 s3Client) {
         final ListObjectsV2Request request = new ListObjectsV2Request().withBucketName(bucketName)
                 .withMaxKeys(s3SourceConfig.getInt(FETCH_PAGE_SIZE) * PAGE_SIZE_FACTOR);
 

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/OffsetManager.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/OffsetManager.java
@@ -16,7 +16,6 @@
 
 package io.aiven.kafka.connect.s3.source.utils;
 
-import static io.aiven.kafka.connect.s3.source.S3SourceTask.OBJECT_KEY;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.ArrayList;
@@ -59,35 +58,50 @@ public class OffsetManager {
         LOGGER.info(" ********** offsets ***** {}", offsets);
     }
 
+    /**
+     * FOR TESTING ONLY
+     *
+     * @param offsets
+     *            the offsets
+     */
+    protected OffsetManager(final Map<Map<String, Object>, Map<String, Object>> offsets) {
+        this.offsets = offsets;
+    }
+
     public Map<Map<String, Object>, Map<String, Object>> getOffsets() {
         return Collections.unmodifiableMap(offsets);
     }
 
     /**
-     * Updates the offset map.  The {@code partitionMap} parameter is only used as a key all data is managed internally.
-     * If the {@code partitionMap} is not found in the internal map then no changes occur and the {@code startOffset} value is
-     * returned. Otherwise:
-     *  <ul>
-     *      <li>If the internal map contains a value for {@code currentObjectKey} the offset is incremented and returned.</li>
-     *      <li>If the internal map does NOT contain a value for {@code currentObjectKey} the offset set to the value of
-     *      {@code startOffset} and that value returned.</li>
-     *  </ul>
-     * @param partitionMap the key to lookup the data in the offsets table.
-     * @param currentObjectKey The object to update the offset for.
-     * @param startOffset The initial value if necessary.
+     * Updates the offset map. The {@code partitionMap} parameter is only used as a key all data is managed internally.
+     * If the {@code partitionMap} is not found in the internal map then no changes occur and the {@code startOffset}
+     * value is returned. Otherwise:
+     * <ul>
+     * <li>If the internal map contains a value for {@code currentObjectKey} the offset is incremented and
+     * returned.</li>
+     * <li>If the internal map does NOT contain a value for {@code currentObjectKey} the offset set to the value of
+     * {@code startOffset} and that value returned.</li>
+     * </ul>
+     *
+     * @param partitionMap
+     *            the key to lookup the data in the offsets table.
+     * @param currentObjectKey
+     *            The object to update the offset for.
+     * @param startOffset
+     *            The initial value if necessary.
      * @return the value of the calculation outlined above.
      */
     public long incrementAndUpdateOffsetMap(final Map<String, Object> partitionMap, final String currentObjectKey,
             final long startOffset) {
         if (offsets.containsKey(partitionMap)) {
             final Map<String, Object> offsetValue = new HashMap<>(offsets.get(partitionMap));
-            if (offsetValue.containsKey(getObjectMapKey(currentObjectKey))) {
-                final long newOffsetVal = (long) offsetValue.get(getObjectMapKey(currentObjectKey)) + 1L;
-                offsetValue.put(getObjectMapKey(currentObjectKey), newOffsetVal);
+            if (offsetValue.containsKey(currentObjectKey)) {
+                final long newOffsetVal = (long) offsetValue.get(currentObjectKey) + 1L;
+                offsetValue.put(currentObjectKey, newOffsetVal);
                 offsets.put(partitionMap, offsetValue);
                 return newOffsetVal;
             } else {
-                offsetValue.put(getObjectMapKey(currentObjectKey), startOffset);
+                offsetValue.put(currentObjectKey, startOffset);
                 offsets.put(partitionMap, offsetValue);
                 return startOffset;
             }
@@ -95,26 +109,20 @@ public class OffsetManager {
         return startOffset;
     }
 
-    public String getObjectMapKey(final String currentObjectKey) {
-        return OBJECT_KEY + SEPARATOR + currentObjectKey;
-    }
-
-    public boolean shouldSkipRecord(S3OffsetManagerEntry offsetManagerEntry) {
+    public boolean shouldSkipRecord(final S3OffsetManagerEntry offsetManagerEntry) {
+        boolean result = false;
+        Map<String, Object> partitionMap = offsetManagerEntry.getManagerKey().getPartitionMap();
         if (offsets.containsKey(offsetManagerEntry.getManagerKey().getPartitionMap())) {
-            final Map<String, Object> offsetVal = offsets.get(offsetManagerEntry.getManagerKey().getPartitionMap());
-            final String objectMapKey = getObjectMapKey(offsetManagerEntry.getKey());
-
-            if (offsetVal.containsKey(objectMapKey)) {
-                final long offsetValue = (long) offsetVal.get(objectMapKey);
-                return offsetManagerEntry.getRecordCount() <= offsetValue;
-            }
+            S3OffsetManagerEntry stored = offsetManagerEntry
+                    .fromProperties(offsets.get(offsetManagerEntry.getManagerKey().getPartitionMap()));
+            result = stored.shouldSkipRecord(offsetManagerEntry.getRecordCount());
         }
-        return false;
+        return result;
     }
 
     public Map<String, Object> getOffsetValueMap(final String currentObjectKey, final long offsetId) {
         final Map<String, Object> offsetMap = new HashMap<>();
-        offsetMap.put(getObjectMapKey(currentObjectKey), offsetId);
+        offsetMap.put(currentObjectKey, offsetId);
 
         return offsetMap;
     }
@@ -151,33 +159,48 @@ public class OffsetManager {
     /**
      * The definition of an entry in the OffsetManager.
      */
-    public static interface OffsetManagerEntry {
+    public interface OffsetManagerEntry {
+
+        /**
+         * Creates a new OffsetManagerEntry by wrapping the properties with the current implementation.
+         *
+         * @param properties
+         *            the properties to wrap.
+         * @return an OffsetManagerProperty
+         */
+        OffsetManagerEntry fromProperties(Map<String, Object> properties);
+
         /**
          * Extract the data from the entry in the correct format to return to Kafka.
+         *
          * @return
          */
         Map<String, Object> getProperties();
 
         /**
-         * Sets a key/value pair.  Will overwrite any existing value.
-         * Implementations of OffsetManagerEntry may declare specific keys as restricted.  These are generally keys
-         * that are managed internally by the OffsetManagerEntry and may not be set except through provided setter
-         * methods or the constructor.
-         * @param key the key to set.
-         * @param value the value to set.
-         * @throws IllegalArgumentException if the key is restricted.
+         * Sets a key/value pair. Will overwrite any existing value. Implementations of OffsetManagerEntry may declare
+         * specific keys as restricted. These are generally keys that are managed internally by the OffsetManagerEntry
+         * and may not be set except through provided setter methods or the constructor.
+         *
+         * @param key
+         *            the key to set.
+         * @param value
+         *            the value to set.
+         * @throws IllegalArgumentException
+         *             if the key is restricted.
          */
         void setProperty(String key, Object value);
 
         /**
          * ManagerKey getManagerKey
+         *
          * @return The offset manager key for this entry.
          */
         OffsetManagerKey getManagerKey();
     }
 
     /**
-     * The OffsetManager Key.  Must override hashCode() and equals().
+     * The OffsetManager Key. Must override hashCode() and equals().
      */
     @FunctionalInterface
     public interface OffsetManagerKey {

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/OffsetManager.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/OffsetManager.java
@@ -79,7 +79,7 @@ public class OffsetManager {
     }
 
     public <T extends OffsetManagerEntry> T getEntry(final OffsetManagerKey key,
-                                                     final Function<Map<String, Object>, T> creator) {
+            final Function<Map<String, Object>, T> creator) {
         return creator.apply(offsets.get(key.getPartitionMap()));
     }
 
@@ -108,7 +108,7 @@ public class OffsetManager {
 
     // TODO move this to S3OffsetManager creation. May not be needed.
     private static List<Map<String, Object>> buildPartitionKeys(final String bucket, final Set<Integer> partitions,
-                                                                final Set<String> topics) {
+            final Set<String> topics) {
         final List<Map<String, Object>> partitionKeys = new ArrayList<>();
         partitions.forEach(partition -> topics.forEach(topic -> {
             partitionKeys.add(ConnectUtils.getPartitionMap(topic, partition, bucket));

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/RecordProcessor.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/RecordProcessor.java
@@ -16,27 +16,19 @@
 
 package io.aiven.kafka.connect.s3.source.utils;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.kafka.connect.data.SchemaAndValue;
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.storage.Converter;
 
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
-import io.aiven.kafka.connect.s3.source.input.Transformer;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class RecordProcessor {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RecordProcessor.class);
+    // private static final Logger LOGGER = LoggerFactory.getLogger(RecordProcessor.class);
 
     private RecordProcessor() {
 
@@ -56,26 +48,26 @@ public final class RecordProcessor {
 
         return results;
     }
-//
-//    static SourceRecord createSourceRecord(final S3SourceRecord s3SourceRecord, final S3SourceConfig s3SourceConfig,
-//            final Optional<Converter> keyConverter, final Converter valueConverter,
-//            final Map<String, String> conversionConfig, final Transformer transformer, final FileReader fileReader,
-//            final OffsetManager offsetManager) {
-//
-//        final String topic = s3SourceRecord.getTopic();
-//        final Optional<SchemaAndValue> keyData = keyConverter.map(c -> c.toConnectData(topic, s3SourceRecord.key()));
-//
-//        transformer.configureValueConverter(conversionConfig, s3SourceConfig);
-//        valueConverter.configure(conversionConfig, false);
-//        try {
-//            final SchemaAndValue schemaAndValue = valueConverter.toConnectData(topic, s3SourceRecord.value());
-//            offsetManager.updateCurrentOffsets(s3SourceRecord.getPartitionMap(), s3SourceRecord.getOffsetMap());
-//            s3SourceRecord.setOffsetMap(offsetManager.getOffsets().get(s3SourceRecord.getPartitionMap()));
-//            return s3SourceRecord.getSourceRecord(keyData, schemaAndValue);
-//        } catch (DataException e) {
-//            LOGGER.error("Error in reading s3 object stream {}", e.getMessage(), e);
-//            fileReader.addFailedObjectKeys(s3SourceRecord.getObjectKey());
-//            throw e;
-//        }
-//    }
+    //
+    // static SourceRecord createSourceRecord(final S3SourceRecord s3SourceRecord, final S3SourceConfig s3SourceConfig,
+    // final Optional<Converter> keyConverter, final Converter valueConverter,
+    // final Map<String, String> conversionConfig, final Transformer transformer, final FileReader fileReader,
+    // final OffsetManager offsetManager) {
+    //
+    // final String topic = s3SourceRecord.getTopic();
+    // final Optional<SchemaAndValue> keyData = keyConverter.map(c -> c.toConnectData(topic, s3SourceRecord.key()));
+    //
+    // transformer.configureValueConverter(conversionConfig, s3SourceConfig);
+    // valueConverter.configure(conversionConfig, false);
+    // try {
+    // final SchemaAndValue schemaAndValue = valueConverter.toConnectData(topic, s3SourceRecord.value());
+    // offsetManager.updateCurrentOffsets(s3SourceRecord.getPartitionMap(), s3SourceRecord.getOffsetMap());
+    // s3SourceRecord.setOffsetMap(offsetManager.getOffsets().get(s3SourceRecord.getPartitionMap()));
+    // return s3SourceRecord.getSourceRecord(keyData, schemaAndValue);
+    // } catch (DataException e) {
+    // LOGGER.error("Error in reading s3 object stream {}", e.getMessage(), e);
+    // fileReader.addFailedObjectKeys(s3SourceRecord.getObjectKey());
+    // throw e;
+    // }
+    // }
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/RecordProcessor.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/RecordProcessor.java
@@ -28,12 +28,10 @@ import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 
 public final class RecordProcessor {
 
-    // private static final Logger LOGGER = LoggerFactory.getLogger(RecordProcessor.class);
-
     private RecordProcessor() {
-
     }
 
+    // TODO: this may move to S3SourceTask.
     public static List<SourceRecord> processRecords(final Iterator<S3SourceRecord> sourceRecordIterator,
             final List<SourceRecord> results, final S3SourceConfig s3SourceConfig,
             final Optional<Converter> keyConverter, final Converter valueConverter,
@@ -48,26 +46,4 @@ public final class RecordProcessor {
 
         return results;
     }
-    //
-    // static SourceRecord createSourceRecord(final S3SourceRecord s3SourceRecord, final S3SourceConfig s3SourceConfig,
-    // final Optional<Converter> keyConverter, final Converter valueConverter,
-    // final Map<String, String> conversionConfig, final Transformer transformer, final FileReader fileReader,
-    // final OffsetManager offsetManager) {
-    //
-    // final String topic = s3SourceRecord.getTopic();
-    // final Optional<SchemaAndValue> keyData = keyConverter.map(c -> c.toConnectData(topic, s3SourceRecord.key()));
-    //
-    // transformer.configureValueConverter(conversionConfig, s3SourceConfig);
-    // valueConverter.configure(conversionConfig, false);
-    // try {
-    // final SchemaAndValue schemaAndValue = valueConverter.toConnectData(topic, s3SourceRecord.value());
-    // offsetManager.updateCurrentOffsets(s3SourceRecord.getPartitionMap(), s3SourceRecord.getOffsetMap());
-    // s3SourceRecord.setOffsetMap(offsetManager.getOffsets().get(s3SourceRecord.getPartitionMap()));
-    // return s3SourceRecord.getSourceRecord(keyData, schemaAndValue);
-    // } catch (DataException e) {
-    // LOGGER.error("Error in reading s3 object stream {}", e.getMessage(), e);
-    // fileReader.addFailedObjectKeys(s3SourceRecord.getObjectKey());
-    // throw e;
-    // }
-    // }
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapper.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapper.java
@@ -1,0 +1,85 @@
+package io.aiven.kafka.connect.s3.source.utils;
+
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+import io.aiven.kafka.connect.s3.source.input.Transformer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.LOGGER;
+
+public final class S3ObjectToSourceRecordMapper implements Function<S3Object, Iterator<S3SourceRecord>> {
+
+    private final TopicPartitionExtractingPredicate topicPartitionExtractingPredicate;
+    private final Transformer transformer;
+
+    private final S3SourceConfig s3SourceConfig;
+
+    private final OffsetManager offsetManager;
+
+    S3ObjectToSourceRecordMapper(final Transformer transformer, final TopicPartitionExtractingPredicate topicPartitionExtractingPredicate, final S3SourceConfig s3SourceConfig, OffsetManager offsetManager) {
+        this.topicPartitionExtractingPredicate = topicPartitionExtractingPredicate;
+        this.transformer = transformer;
+        this.s3SourceConfig = s3SourceConfig;
+        this.offsetManager = offsetManager;
+    }
+
+    /**
+     * Filters out offsets that we have already processed.
+     */
+    private class RecordFilter implements Predicate<Object> {
+        private final S3OffsetManagerEntry offsetManagerEntry;
+        RecordFilter(S3OffsetManagerEntry offsetManagerEntry) {
+            this.offsetManagerEntry = offsetManagerEntry;
+        }
+        private boolean result = false;
+
+        @Override
+        public boolean test(Object o) {
+            if (!result) {
+                result = !offsetManager.shouldSkipRecord(offsetManagerEntry);
+            }
+            offsetManagerEntry.incrementRecordCount();
+            return result;
+        }
+    }
+
+    @Override
+    public Iterator<S3SourceRecord> apply(final S3Object s3Object) {
+        final byte[] keyBytes = s3Object.getKey().getBytes(StandardCharsets.UTF_8);
+        S3OffsetManagerEntry offsetManagerEntry = topicPartitionExtractingPredicate.getOffsetMapEntry();
+        // TODO: Make Transformer set values in the OffsetManagerEntry directly.
+        Map<String, String> propertyMap = new HashMap<>();
+        transformer.configureValueConverter(propertyMap, s3SourceConfig);
+        propertyMap.entrySet().forEach(e -> offsetManagerEntry.setProperty(e.getKey(), e.getValue()));
+        // TODO remove the above block
+        List<Object> records = null;
+        try (S3ObjectInputStream inputStream = s3Object.getObjectContent()) {
+           records = transformer.getRecords(inputStream, offsetManagerEntry.getTopic(), offsetManagerEntry.getPartition(), s3SourceConfig);
+        } catch (IOException e) {
+            LOGGER.error("Error closing input stream for {}", s3Object.getKey(), e);
+            if (records == null) {
+                return Collections.emptyIterator();
+            }
+        }
+
+        RecordFilter recordFilter = new RecordFilter(offsetManagerEntry);
+
+        return records.stream().filter(recordFilter).map(o -> transformer.getValueBytes(o, offsetManagerEntry.getTopic(), s3SourceConfig))
+                // convert byte[] to sourceRecord while updating offset manager.
+                .map(valueBytes -> {
+                    return new S3SourceRecord(offsetManagerEntry, keyBytes, valueBytes);
+                })
+                .iterator();
+    }
+}

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapper.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapper.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import io.aiven.kafka.connect.common.source.offsets.OffsetManager;
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapper.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapper.java
@@ -34,15 +34,34 @@ import io.aiven.kafka.connect.s3.source.input.Transformer;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 
+/**
+ * Converts S3Objects into an Iterator of S3SourceRecords.
+ */
 public final class S3ObjectToSourceRecordMapper implements Function<S3Object, Iterator<S3SourceRecord>> {
-
+    /**
+     * The source of topic and partition for the current S3Object.
+     * As the S3ObjectSummaries are read this instance will be updated.  It will always be the
+     * values fro the S3Object that is being processed.
+     */
     private final TopicPartitionExtractingPredicate topicPartitionExtractingPredicate;
+    /** The transformer to transform the data streams with */
     private final Transformer transformer;
-
+    /**
+     * She S3Source configuration.
+     */
     private final S3SourceConfig s3SourceConfig;
-
+    /**
+     * THe offset manager.
+     */
     private final OffsetManager offsetManager;
 
+    /**
+     * Creats the record mapper.
+     * @param transformer the Transformer to transform data from S3 input streams into records.
+     * @param topicPartitionExtractingPredicate The class that contains the topic and partition the current S3Object.
+     * @param s3SourceConfig The configuration.
+     * @param offsetManager The OffsetManager.
+     */
     S3ObjectToSourceRecordMapper(final Transformer transformer,
             final TopicPartitionExtractingPredicate topicPartitionExtractingPredicate,
             final S3SourceConfig s3SourceConfig, final OffsetManager offsetManager) {
@@ -54,6 +73,9 @@ public final class S3ObjectToSourceRecordMapper implements Function<S3Object, It
 
     /**
      * Filters out offsets that we have already processed.
+     * This filter will filter out records that have been seen.
+     * Once a new record is located it will stop filtering.
+     * The {@code Object} being filtered is the Object returned from the {@link Transformer}
      */
     private class RecordFilter implements Predicate<Object> {
         private final S3OffsetManagerEntry offsetManagerEntry;
@@ -68,21 +90,17 @@ public final class S3ObjectToSourceRecordMapper implements Function<S3Object, It
             // negation of checkRecordSkip.
             if (checkRecordSkip) {
                S3OffsetManagerEntry stored = offsetManager.getEntry(offsetManagerEntry.getManagerKey(),  map -> offsetManagerEntry.fromProperties(map));
-               if (stored != null) {
-                   boolean skipRecord = stored.compareTo(offsetManagerEntry) <= 0 && stored.wasProcessed();
-                   checkRecordSkip = !skipRecord;
-               } else {
-                   checkRecordSkip = false;
-               }
+               checkRecordSkip = stored != null ? stored.compareTo(offsetManagerEntry) <= 0  : false;
             }
             offsetManagerEntry.incrementRecordCount();
+            // this class is a predicate so we have to return true if we want to process the record.
             return !checkRecordSkip;
         }
     }
 
     @Override
     public Iterator<S3SourceRecord> apply(final S3Object s3Object) {
-        final S3OffsetManagerEntry offsetManagerEntry = topicPartitionExtractingPredicate.getOffsetMapEntry();
+        final S3OffsetManagerEntry offsetManagerEntry = topicPartitionExtractingPredicate.getOffsetMnagerEntry();
         // TODO: Make Transformer set values in the OffsetManagerEntry directly.
         final Map<String, String> propertyMap = new HashMap<>();
         transformer.configureValueConverter(propertyMap, s3SourceConfig);
@@ -99,6 +117,8 @@ public final class S3ObjectToSourceRecordMapper implements Function<S3Object, It
             }
         }
 
+        // This filter will determine which records to process.  It may make more sense to
+        // TODO: push this down into the Transformer.  We may also want to implement more complex checks.
         final RecordFilter recordFilter = new RecordFilter(offsetManagerEntry);
         final byte[] keyBytes = s3Object.getKey().getBytes(StandardCharsets.UTF_8);
 

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManager.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManager.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.source.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.source.SourceTaskContext;
+
+import io.aiven.kafka.connect.common.source.offsets.OffsetManager;
+import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+
+public class S3OffsetManager extends OffsetManager {
+
+    public S3OffsetManager(final SourceTaskContext context, final S3SourceConfig s3SourceConfig) {
+        super(context, initializePartitionKeys(s3SourceConfig));
+    }
+
+    /**
+     * FOR TESTING ONLY
+     *
+     * @param offsets
+     *            the offsets
+     */
+    protected S3OffsetManager(final Map<Map<String, Object>, Map<String, Object>> offsets) {
+        super(offsets);
+    }
+
+    private static List<Map<String, Object>> initializePartitionKeys(final S3SourceConfig s3SourceConfig) {
+        final String s3Bucket = s3SourceConfig.getString(S3SourceConfig.AWS_S3_BUCKET_NAME_CONFIG);
+        final Set<Integer> partitions = parsePartitions(s3SourceConfig);
+        final Set<String> topics = parseTopics(s3SourceConfig);
+        // Build the partition keys and fetch offsets from offset storage
+        return buildPartitionKeys(s3Bucket, partitions, topics);
+    }
+
+    private static Set<Integer> parsePartitions(final S3SourceConfig s3SourceConfig) {
+        final String partitionString = s3SourceConfig.getString(S3SourceConfig.TARGET_TOPIC_PARTITIONS);
+        return Arrays.stream(partitionString.split(",")).map(Integer::parseInt).collect(Collectors.toSet());
+    }
+
+    private static Set<String> parseTopics(final S3SourceConfig s3SourceConfig) {
+        final String topicString = s3SourceConfig.getString(S3SourceConfig.TARGET_TOPICS);
+        return Arrays.stream(topicString.split(",")).collect(Collectors.toSet());
+    }
+
+    // TODO can this be done in a cleaner way? May not be needed.
+    private static List<Map<String, Object>> buildPartitionKeys(final String bucket, final Set<Integer> partitions,
+            final Set<String> topics) {
+        final List<Map<String, Object>> partitionKeys = new ArrayList<>();
+        partitions.forEach(partition -> topics.forEach(topic -> {
+            partitionKeys.add(ConnectUtils.getPartitionMap(topic, partition, bucket));
+        }));
+        return partitionKeys;
+    }
+}

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
@@ -20,23 +20,41 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry<S3OffsetManagerEntry> {
 
     // package private statics for testing.
-    static final String BUCKET = "bucket";
-    static final String OBJECT_KEY = "objectKey";
-    static final String TOPIC = "topic";
-    static final String PARTITION = "partition";
+    // TODO make this private after values in S3SourceTask are no longer needed
+    public static final String BUCKET = "bucket";
+    public static final String OBJECT_KEY = "objectKey";
+    public static final String TOPIC = "topic";
+    public static final String PARTITION = "partition";
     static final String RECORD_COUNT = "recordCount";
 
-    private static final long UNSET = -1L;
-
+    /**
+     * THe list of Keys that may not be set via {@link #setProperty(String, Object)}.
+     */
     static final List<String> RESTRICTED_KEYS = List.of(BUCKET, OBJECT_KEY, TOPIC, PARTITION, RECORD_COUNT);
+    /** The data map that stores all the values */
     private final Map<String, Object> data;
+    /** THe record count for the data map. Extracted here because it is used/updated frequently duirng processing */
     private long recordCount;
 
+    /**
+     * Constructs
+     *
+     * @param bucket
+     *            The S3 bucket that will be tracked in the offsets
+     * @param s3ObjectKey
+     *            The key in the bucket that will be tracked in the offsets
+     * @param topic
+     *            The topic which will be tracked in the offsets
+     * @param partition
+     *            the partition which will be tracked in the offsets
+     */
     public S3OffsetManagerEntry(final String bucket, final String s3ObjectKey, final String topic,
-            final Integer partition) {
+                                final Integer partition) {
         data = new HashMap<>();
         data.put(BUCKET, bucket);
         data.put(OBJECT_KEY, s3ObjectKey);
@@ -44,19 +62,52 @@ public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry<S3
         data.put(PARTITION, partition);
     }
 
+    /**
+     * Constructs an OffsetManagerEntry from an existing map. used by {@link #fromProperties(Map)}.
+     *
+     * @param properties
+     *            the property map.
+     */
+    @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
+    private S3OffsetManagerEntry(final Map<String, Object> properties) {
+        data = new HashMap<>();
+        data.putAll(properties);
+        for (final String field : RESTRICTED_KEYS) {
+            if (data.get(field) == null) {
+                throw new IllegalArgumentException("Missing '" + field + "' property");
+            }
+        }
+    }
+
+    /**
+     * Creates an S3OffsetManagerEntry. Will return {@code null} if properties is {@code null}.
+     *
+     * @param properties
+     *            the properties to wrap. May be {@code null}.
+     * @return an S3OffsetManagerEntry.
+     * @throws IllegalArgumentException
+     *             if one of the {@link #RESTRICTED_KEYS} is missing.
+     */
     @Override
     public S3OffsetManagerEntry fromProperties(final Map<String, Object> properties) {
-        S3OffsetManagerEntry result = new S3OffsetManagerEntry(properties);
-        Long recordCount = (Long) properties.get(RECORD_COUNT);
+        if (properties == null) {
+            return null;
+        }
+        final Long recordCount = (Long) properties.get(RECORD_COUNT);
+
+        final S3OffsetManagerEntry result = new S3OffsetManagerEntry(properties);
         if (recordCount != null) {
             result.recordCount = recordCount;
         }
         return result;
     }
 
-    private S3OffsetManagerEntry(final Map<String, Object> properties) {
-        data = new HashMap<>();
-        data.putAll(properties);
+    @Override
+    public Object getProperty(final String key) {
+        if (RECORD_COUNT.equals(key)) {
+            return recordCount;
+        }
+        return data.get(key);
     }
 
     @Override
@@ -68,28 +119,49 @@ public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry<S3
         data.put(property, value);
     }
 
+    /**
+     * Increment the record count and return the result.
+     *
+     * @return the new record count value.
+     */
     public long incrementRecordCount() {
         return recordCount += 1;
     }
 
+    /**
+     * Gets the umber of records extracted from data returned from S3.
+     *
+     * @return the umber of records extracted from data returned from S3.
+     */
     public long getRecordCount() {
         return recordCount;
     }
 
+    /**
+     * Gets the S3Object key for the current object.
+     *
+     * @return the S3ObjectKey.
+     */
     public String getKey() {
         return (String) data.get(OBJECT_KEY);
     }
 
+    /**
+     * Gets the Kafka partition number for the current object.
+     *
+     * @return the Kafka partition number for the current object.
+     */
     public Integer getPartition() {
         return (Integer) data.get(PARTITION);
     }
 
+    /**
+     * Gets the Kafka topic for the current object.
+     *
+     * @return the Kafka topic for the current object..
+     */
     public String getTopic() {
         return (String) data.get(TOPIC);
-    }
-
-    public boolean shouldSkipRecord(final long candidateRecord) {
-        return candidateRecord < recordCount;
     }
 
     /**
@@ -104,9 +176,36 @@ public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry<S3
         return result;
     }
 
+    /**
+     * Returns the OffsetManagerKey for this Entry.
+     *
+     * @return the OffsetManagerKey for this Entry.
+     */
     @Override
     public OffsetManager.OffsetManagerKey getManagerKey() {
-        return () -> Map.of(BUCKET, data.get(BUCKET), TOPIC, data.get(TOPIC), PARTITION, data.get(PARTITION));
+        return () -> Map.of(BUCKET, data.get(BUCKET), TOPIC, data.get(TOPIC), PARTITION, data.get(PARTITION),
+                OBJECT_KEY, data.get(OBJECT_KEY));
     }
 
+    @SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
+    @Override
+    public int compareTo(final S3OffsetManagerEntry other) {
+        if (this == other) { // NOPMD should use compare
+            return 0;
+        }
+        int result = ((String) getProperty(BUCKET)).compareTo((String) other.getProperty(BUCKET));
+        if (result == 0) {
+            result = getTopic().compareTo(other.getTopic());
+            if (result == 0) {
+                result = getPartition().compareTo(other.getPartition());
+                if (result == 0) { // NOPMD deeply nested
+                    result = getKey().compareTo(other.getKey());
+                    if (result == 0) {
+                        result = Long.compare(getRecordCount(), other.getRecordCount());
+                    }
+                }
+            }
+        }
+        return result;
+    }
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
@@ -1,0 +1,76 @@
+package io.aiven.kafka.connect.s3.source.utils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry {
+
+    // package private statics for testing.
+    static final String BUCKET = "bucket";
+    static final String OBJECT_KEY = "objectKey";
+    static final String TOPIC = "topic";
+    static final String PARTITION = "partition";
+    static final String RECORD_COUNT = "recordCount";
+
+    static final List<String> RESTRICTED_KEYS = List.of(BUCKET, OBJECT_KEY, TOPIC, PARTITION, RECORD_COUNT);
+    private final Map<String, Object> data;
+    private long recordCount;
+
+
+    public S3OffsetManagerEntry(final String bucket, final String s3ObjectKey, final String topic, final Integer partition) {
+        data = new HashMap<>();
+        data.put(BUCKET, bucket);
+        data.put(OBJECT_KEY, s3ObjectKey);
+        data.put(TOPIC, topic);
+        data.put(PARTITION, partition);
+    }
+
+    public void setProperty(String property, Object value) {
+        if (RESTRICTED_KEYS.contains(property)) {
+            throw new IllegalArgumentException(String.format("'%s' is a restricted key and may not be set using setProperty()", property));
+        }
+        data.put(property, value);
+    }
+
+    public long incrementRecordCount() {
+        return recordCount += 1;
+    }
+
+    public long getRecordCount() {
+        return recordCount;
+    }
+
+    public String getKey() {
+        return (String) data.get(OBJECT_KEY);
+    }
+
+    public Integer getPartition() {
+        return (Integer) data.get(PARTITION);
+    }
+
+    public String getTopic() {
+        return (String) data.get(TOPIC);
+    }
+
+    public boolean shouldSkipRecord(long candidateRecord) {
+        return candidateRecord < recordCount;
+    };
+
+    /**
+     * Creates a new offset map.  No defensive copy is necessary.
+     * @return a new map of properties and values.
+     */
+    @Override
+    public Map<String, Object> getProperties() {
+        Map<String, Object> result = new HashMap<>(data);
+        result.put(RECORD_COUNT, recordCount);
+        return result;
+    }
+
+    public OffsetManager.OffsetManagerKey getManagerKey() {
+        return () -> Map.of(
+            BUCKET, data.get(BUCKET), TOPIC, data.get(TOPIC), PARTITION, data.get(PARTITION));
+    }
+
+}

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry {
+public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry<S3OffsetManagerEntry> {
 
     // package private statics for testing.
     static final String BUCKET = "bucket";

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
@@ -54,7 +54,7 @@ public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry<S3
      *            the partition which will be tracked in the offsets
      */
     public S3OffsetManagerEntry(final String bucket, final String s3ObjectKey, final String topic,
-                                final Integer partition) {
+            final Integer partition) {
         data = new HashMap<>();
         data.put(BUCKET, bucket);
         data.put(OBJECT_KEY, s3ObjectKey);

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.aiven.kafka.connect.common.source.offsets.OffsetManager;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry<S3OffsetManagerEntry> {

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.s3.source.utils;
 
 import java.util.HashMap;
@@ -13,12 +29,14 @@ public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry {
     static final String PARTITION = "partition";
     static final String RECORD_COUNT = "recordCount";
 
+    private static final long UNSET = -1L;
+
     static final List<String> RESTRICTED_KEYS = List.of(BUCKET, OBJECT_KEY, TOPIC, PARTITION, RECORD_COUNT);
     private final Map<String, Object> data;
     private long recordCount;
 
-
-    public S3OffsetManagerEntry(final String bucket, final String s3ObjectKey, final String topic, final Integer partition) {
+    public S3OffsetManagerEntry(final String bucket, final String s3ObjectKey, final String topic,
+            final Integer partition) {
         data = new HashMap<>();
         data.put(BUCKET, bucket);
         data.put(OBJECT_KEY, s3ObjectKey);
@@ -26,9 +44,26 @@ public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry {
         data.put(PARTITION, partition);
     }
 
-    public void setProperty(String property, Object value) {
+    @Override
+    public S3OffsetManagerEntry fromProperties(final Map<String, Object> properties) {
+        S3OffsetManagerEntry result = new S3OffsetManagerEntry(properties);
+        Long recordCount = (Long) properties.get(RECORD_COUNT);
+        if (recordCount != null) {
+            result.recordCount = recordCount;
+        }
+        return result;
+    }
+
+    private S3OffsetManagerEntry(final Map<String, Object> properties) {
+        data = new HashMap<>();
+        data.putAll(properties);
+    }
+
+    @Override
+    public void setProperty(final String property, final Object value) {
         if (RESTRICTED_KEYS.contains(property)) {
-            throw new IllegalArgumentException(String.format("'%s' is a restricted key and may not be set using setProperty()", property));
+            throw new IllegalArgumentException(
+                    String.format("'%s' is a restricted key and may not be set using setProperty()", property));
         }
         data.put(property, value);
     }
@@ -53,24 +88,25 @@ public class S3OffsetManagerEntry implements OffsetManager.OffsetManagerEntry {
         return (String) data.get(TOPIC);
     }
 
-    public boolean shouldSkipRecord(long candidateRecord) {
+    public boolean shouldSkipRecord(final long candidateRecord) {
         return candidateRecord < recordCount;
-    };
+    }
 
     /**
-     * Creates a new offset map.  No defensive copy is necessary.
+     * Creates a new offset map. No defensive copy is necessary.
+     *
      * @return a new map of properties and values.
      */
     @Override
     public Map<String, Object> getProperties() {
-        Map<String, Object> result = new HashMap<>(data);
+        final Map<String, Object> result = new HashMap<>(data);
         result.put(RECORD_COUNT, recordCount);
         return result;
     }
 
+    @Override
     public OffsetManager.OffsetManagerKey getManagerKey() {
-        return () -> Map.of(
-            BUCKET, data.get(BUCKET), TOPIC, data.get(TOPIC), PARTITION, data.get(PARTITION));
+        return () -> Map.of(BUCKET, data.get(BUCKET), TOPIC, data.get(TOPIC), PARTITION, data.get(PARTITION));
     }
 
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecord.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecord.java
@@ -16,11 +16,8 @@
 
 package io.aiven.kafka.connect.s3.source.utils;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.Optional;
 
-import org.apache.avro.generic.GenericData;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.storage.Converter;

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecord.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecord.java
@@ -16,8 +16,6 @@
 
 package io.aiven.kafka.connect.s3.source.utils;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -33,13 +31,12 @@ public class S3SourceRecord {
     private final byte[] recordKey;
     private final byte[] recordValue;
 
-
-    public S3SourceRecord(final S3OffsetManagerEntry offsetManagerEntry, final byte[] recordKey, final byte[] recordValue) {
+    public S3SourceRecord(final S3OffsetManagerEntry offsetManagerEntry, final byte[] recordKey,
+            final byte[] recordValue) {
         this.recordKey = recordKey.clone(); // Defensive copy
         this.recordValue = recordValue.clone(); // Defensive copy
         this.offsetManagerEntry = offsetManagerEntry;
     }
-
 
     public Map<String, Object> getPartitionMap() {
         return offsetManagerEntry.getManagerKey().getPartitionMap();
@@ -50,18 +47,30 @@ public class S3SourceRecord {
     }
 
     public SourceRecord getSourceRecord(final Optional<Converter> keyConverter, final Converter valueConverter) {
-        final Optional<SchemaAndValue> keyData = keyConverter.map(c -> c.toConnectData(offsetManagerEntry.getTopic(), recordKey));
+        final Optional<SchemaAndValue> keyData = keyConverter
+                .map(c -> c.toConnectData(offsetManagerEntry.getTopic(), recordKey));
 
-        //transformer.configureValueConverter(conversionConfig, s3SourceConfig);
-        //valueConverter.configure(conversionConfig, false);
+        // transformer.configureValueConverter(conversionConfig, s3SourceConfig);
+        // valueConverter.configure(conversionConfig, false);
 
         final SchemaAndValue schemaAndValue = valueConverter.toConnectData(offsetManagerEntry.getTopic(), recordValue);
-//        offsetManager.updateCurrentOffsets(s3SourceRecord.getPartitionMap(), s3SourceRecord.getOffsetMap());
- //       s3SourceRecord.setOffsetMap(offsetManager.getOffsets().get(s3SourceRecord.getPartitionMap()));
-//        return s3SourceRecord.getSourceRecord(keyData, schemaAndValue);
+        // offsetManager.updateCurrentOffsets(s3SourceRecord.getPartitionMap(), s3SourceRecord.getOffsetMap());
+        // s3SourceRecord.setOffsetMap(offsetManager.getOffsets().get(s3SourceRecord.getPartitionMap()));
+        // return s3SourceRecord.getSourceRecord(keyData, schemaAndValue);
 
-        return new SourceRecord(offsetManagerEntry.getManagerKey().getPartitionMap(), offsetManagerEntry.getProperties(), offsetManagerEntry.getTopic(), offsetManagerEntry.getPartition(),
+        return new SourceRecord(offsetManagerEntry.getManagerKey().getPartitionMap(),
+                offsetManagerEntry.getProperties(), offsetManagerEntry.getTopic(), offsetManagerEntry.getPartition(),
                 keyData.map(SchemaAndValue::schema).orElse(null), keyData.map(SchemaAndValue::value).orElse(null),
                 schemaAndValue.schema(), schemaAndValue.value());
+    }
+
+    // package private for testing
+    byte[] getRecordKey() {
+        return recordKey.clone();
+    }
+
+    // package private for testing.
+    byte[] getRecordValue() {
+        return recordValue.clone();
     }
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecord.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecord.java
@@ -16,9 +16,11 @@
 
 package io.aiven.kafka.connect.s3.source.utils;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.avro.generic.GenericData;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.storage.Converter;
@@ -27,37 +29,25 @@ import org.apache.kafka.connect.storage.Converter;
  * The Source record that contains the offset manager data as well.
  */
 public class S3SourceRecord {
+    /** The S3OffsetManagerEntry for this source record */
     private final S3OffsetManagerEntry offsetManagerEntry;
+    /** The Kakka record Key */
     private final byte[] recordKey;
+    /** The Kafka record value */
     private final byte[] recordValue;
 
     public S3SourceRecord(final S3OffsetManagerEntry offsetManagerEntry, final byte[] recordKey,
             final byte[] recordValue) {
-        this.recordKey = recordKey.clone(); // Defensive copy
-        this.recordValue = recordValue.clone(); // Defensive copy
-        this.offsetManagerEntry = offsetManagerEntry;
-    }
-
-    public Map<String, Object> getPartitionMap() {
-        return offsetManagerEntry.getManagerKey().getPartitionMap();
-    }
-
-    public Map<String, Object> getOffsetMap() {
-        return offsetManagerEntry.getProperties();
+        // make defensive copies.
+        this.recordKey = recordKey.clone();
+        this.recordValue = recordValue.clone();
+        this.offsetManagerEntry = offsetManagerEntry.fromProperties(offsetManagerEntry.getProperties());
     }
 
     public SourceRecord getSourceRecord(final Optional<Converter> keyConverter, final Converter valueConverter) {
         final Optional<SchemaAndValue> keyData = keyConverter
                 .map(c -> c.toConnectData(offsetManagerEntry.getTopic(), recordKey));
-
-        // transformer.configureValueConverter(conversionConfig, s3SourceConfig);
-        // valueConverter.configure(conversionConfig, false);
-
         final SchemaAndValue schemaAndValue = valueConverter.toConnectData(offsetManagerEntry.getTopic(), recordValue);
-        // offsetManager.updateCurrentOffsets(s3SourceRecord.getPartitionMap(), s3SourceRecord.getOffsetMap());
-        // s3SourceRecord.setOffsetMap(offsetManager.getOffsets().get(s3SourceRecord.getPartitionMap()));
-        // return s3SourceRecord.getSourceRecord(keyData, schemaAndValue);
-
         return new SourceRecord(offsetManagerEntry.getManagerKey().getPartitionMap(),
                 offsetManagerEntry.getProperties(), offsetManagerEntry.getTopic(), offsetManagerEntry.getPartition(),
                 keyData.map(SchemaAndValue::schema).orElse(null), keyData.map(SchemaAndValue::value).orElse(null),

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIterator.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIterator.java
@@ -19,6 +19,7 @@ package io.aiven.kafka.connect.s3.source.utils;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import io.aiven.kafka.connect.common.source.offsets.OffsetManager;
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIterator.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIterator.java
@@ -16,30 +16,15 @@
 
 package io.aiven.kafka.connect.s3.source.utils;
 
-import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.MAX_POLL_RECORDS;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 
-import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.apache.commons.collections4.IteratorUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Iterator that processes S3 files and creates Kafka source records. Supports different output formats (Avro, JSON,
@@ -49,19 +34,28 @@ public final class SourceRecordIterator implements Iterator<S3SourceRecord> {
 
     /** The S3SourceRecord Iterator that we will return values from */
     private Iterator<S3SourceRecord> outer;
-    /** The Iterator of Iterators of S3SourceRecords that we will process.  The inner iterator feeds the outer iterator*/
+    /**
+     * The Iterator of Iterators of S3SourceRecords that we will process. The inner iterator feeds the outer iterator
+     */
     private final Iterator<Iterator<S3SourceRecord>> inner;
 
     /**
      * Constructor.
-     * @param s3SourceConfig The S3 source configuration.
-     * @param s3Client The s3Client that we are reading from.
-     * @param offsetManager the Offset manager for this source package.
-     * @param transformer the Transformer to convert S3 data to Kafka data.
-     * @param s3ObjectSummaryIterator The iterator of S3ObjectSummaries.
+     *
+     * @param s3SourceConfig
+     *            The S3 source configuration.
+     * @param s3Client
+     *            The s3Client that we are reading from.
+     * @param offsetManager
+     *            the Offset manager for this source package.
+     * @param transformer
+     *            the Transformer to convert S3 data to Kafka data.
+     * @param s3ObjectSummaryIterator
+     *            The iterator of S3ObjectSummaries.
      */
     public SourceRecordIterator(final S3SourceConfig s3SourceConfig, final AmazonS3 s3Client,
-                                final OffsetManager offsetManager, final Transformer transformer, final Iterator<S3ObjectSummary> s3ObjectSummaryIterator) {
+            final OffsetManager offsetManager, final Transformer transformer,
+            final Iterator<S3ObjectSummary> s3ObjectSummaryIterator) {
         final TopicPartitionExtractingPredicate topicPartitionExtractingPredicate = new TopicPartitionExtractingPredicate();
         final S3ObjectToSourceRecordMapper sourceToRecordMapper = new S3ObjectToSourceRecordMapper(transformer,
                 topicPartitionExtractingPredicate, s3SourceConfig, offsetManager);

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/TopicPartitionExtractingPredicate.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/TopicPartitionExtractingPredicate.java
@@ -1,0 +1,45 @@
+package io.aiven.kafka.connect.s3.source.utils;
+
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class TopicPartitionExtractingPredicate implements Predicate<S3ObjectSummary> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SourceRecordIterator.class);
+    public static final String PATTERN_TOPIC_KEY = "topicName";
+    public static final String PATTERN_PARTITION_KEY = "partitionId";
+
+    public static final Pattern FILE_DEFAULT_PATTERN = Pattern.compile("(?<topicName>[^/]+?)-"
+            + "(?<partitionId>\\d{5})-" + "(?<uniqueId>[a-zA-Z0-9]+)" + "\\.(?<fileExtension>[^.]+)$"); // topic-00001.txt
+
+    private S3OffsetManagerEntry offsetManagerEntry;
+
+    public TopicPartitionExtractingPredicate() {
+    }
+
+    public S3OffsetManagerEntry getOffsetMapEntry() {
+        return offsetManagerEntry;
+    }
+
+    @Override
+    public boolean test(S3ObjectSummary s3ObjectSummary) {
+        final Matcher fileMatcher = FILE_DEFAULT_PATTERN.matcher(s3ObjectSummary.getKey());
+
+        if (fileMatcher.find()) {
+            try {
+                offsetManagerEntry = new S3OffsetManagerEntry(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey(), fileMatcher.group(PATTERN_TOPIC_KEY), Integer.parseInt(fileMatcher.group(PATTERN_PARTITION_KEY)));
+            } catch (Exception e) {
+                LOGGER.error("Error parsing offset data from {}", s3ObjectSummary.getKey(), e);
+                offsetManagerEntry = null;
+                return false;
+            }
+            return true;
+        }
+        LOGGER.error("File naming doesn't match to any topic. {}", s3ObjectSummary.getKey());
+        return false;
+    }
+}

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/TopicPartitionExtractingPredicate.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/TopicPartitionExtractingPredicate.java
@@ -1,12 +1,28 @@
-package io.aiven.kafka.connect.s3.source.utils;
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import com.amazonaws.services.s3.model.S3ObjectSummary;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+package io.aiven.kafka.connect.s3.source.utils;
 
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class TopicPartitionExtractingPredicate implements Predicate<S3ObjectSummary> {
     private static final Logger LOGGER = LoggerFactory.getLogger(SourceRecordIterator.class);
@@ -18,23 +34,22 @@ public final class TopicPartitionExtractingPredicate implements Predicate<S3Obje
 
     private S3OffsetManagerEntry offsetManagerEntry;
 
-    public TopicPartitionExtractingPredicate() {
-    }
-
     public S3OffsetManagerEntry getOffsetMapEntry() {
         return offsetManagerEntry;
     }
 
     @Override
-    public boolean test(S3ObjectSummary s3ObjectSummary) {
+    public boolean test(final S3ObjectSummary s3ObjectSummary) {
         final Matcher fileMatcher = FILE_DEFAULT_PATTERN.matcher(s3ObjectSummary.getKey());
 
         if (fileMatcher.find()) {
             try {
-                offsetManagerEntry = new S3OffsetManagerEntry(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey(), fileMatcher.group(PATTERN_TOPIC_KEY), Integer.parseInt(fileMatcher.group(PATTERN_PARTITION_KEY)));
-            } catch (Exception e) {
+                offsetManagerEntry = new S3OffsetManagerEntry(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey(),
+                        fileMatcher.group(PATTERN_TOPIC_KEY),
+                        Integer.parseInt(fileMatcher.group(PATTERN_PARTITION_KEY)));
+            } catch (RuntimeException e) { // NOPMD AvoidCatchingGenericException
                 LOGGER.error("Error parsing offset data from {}", s3ObjectSummary.getKey(), e);
-                offsetManagerEntry = null;
+                offsetManagerEntry = null; // NOPMD NullAssignment
                 return false;
             }
             return true;

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/TopicPartitionExtractingPredicate.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/TopicPartitionExtractingPredicate.java
@@ -24,17 +24,33 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A predicate that extracts the topic and partition from the S3ObjectSummary key.
+ * Will ignore S3ObjectSummary for which the keys can not be parsed.
+ */
 public final class TopicPartitionExtractingPredicate implements Predicate<S3ObjectSummary> {
+    /** THe logger to use */
     private static final Logger LOGGER = LoggerFactory.getLogger(SourceRecordIterator.class);
+    /** The name for the topic key */
     public static final String PATTERN_TOPIC_KEY = "topicName";
+    /** The name of the partition key */
     public static final String PATTERN_PARTITION_KEY = "partitionId";
 
+    /** The Regex pattern to match file names */
     public static final Pattern FILE_DEFAULT_PATTERN = Pattern.compile("(?<topicName>[^/]+?)-"
             + "(?<partitionId>\\d{5})-" + "(?<uniqueId>[a-zA-Z0-9]+)" + "\\.(?<fileExtension>[^.]+)$"); // topic-00001.txt
 
+    // TODO: replace the file name matching with the pattern matching in common.
+
+    /** The S3OffsetManagerEntry that is created when the topic and partition are discovered. */
     private S3OffsetManagerEntry offsetManagerEntry;
 
-    public S3OffsetManagerEntry getOffsetMapEntry() {
+    /**
+     * Return the S3OffsetManagerEntry that is associated with the S3ObjectSummary.  This method will return {@code null} if no
+     * files have been processed or if the last file processed did not have a parsable S3ObjectSummary key.
+     * @return the offset manager entry or {@code null} if not available.
+     */
+    public S3OffsetManagerEntry getOffsetMnagerEntry() {
         return offsetManagerEntry;
     }
 

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/TopicPartitionExtractingPredicate.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/TopicPartitionExtractingPredicate.java
@@ -21,12 +21,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A predicate that extracts the topic and partition from the S3ObjectSummary key.
- * Will ignore S3ObjectSummary for which the keys can not be parsed.
+ * A predicate that extracts the topic and partition from the S3ObjectSummary key. Will ignore S3ObjectSummary for which
+ * the keys can not be parsed.
  */
 public final class TopicPartitionExtractingPredicate implements Predicate<S3ObjectSummary> {
     /** THe logger to use */
@@ -46,10 +47,12 @@ public final class TopicPartitionExtractingPredicate implements Predicate<S3Obje
     private S3OffsetManagerEntry offsetManagerEntry;
 
     /**
-     * Return the S3OffsetManagerEntry that is associated with the S3ObjectSummary.  This method will return {@code null} if no
-     * files have been processed or if the last file processed did not have a parsable S3ObjectSummary key.
+     * Return the S3OffsetManagerEntry that is associated with the S3ObjectSummary. This method will return {@code null}
+     * if no files have been processed or if the last file processed did not have a parsable S3ObjectSummary key.
+     *
      * @return the offset manager entry or {@code null} if not available.
      */
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public S3OffsetManagerEntry getOffsetMnagerEntry() {
         return offsetManagerEntry;
     }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/S3SourceTaskTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/S3SourceTaskTest.java
@@ -23,12 +23,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 
+import io.aiven.kafka.connect.s3.source.utils.S3OffsetManagerEntry;
 import org.apache.kafka.connect.converters.ByteArrayConverter;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
@@ -173,7 +175,8 @@ final class S3SourceTaskTest {
     }
 
     private static S3SourceRecord getAivenS3SourceRecord() {
-        return new S3SourceRecord(new HashMap<>(), new HashMap<>(), "testtopic", 0, new byte[0], new byte[0], "");
+        S3OffsetManagerEntry offsetManagerEntry = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "testtopic", 0);
+        return new S3SourceRecord(offsetManagerEntry, "mock-key".getBytes(StandardCharsets.UTF_8), "mock-value".getBytes(StandardCharsets.UTF_8));
     }
 
     @SuppressWarnings("PMD.AvoidAccessibilityAlteration")

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/S3SourceTaskTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/S3SourceTaskTest.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 
-import io.aiven.kafka.connect.s3.source.utils.S3OffsetManagerEntry;
 import org.apache.kafka.connect.converters.ByteArrayConverter;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
@@ -42,6 +41,7 @@ import io.aiven.kafka.connect.s3.source.input.ByteArrayTransformer;
 import io.aiven.kafka.connect.s3.source.input.InputFormat;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 import io.aiven.kafka.connect.s3.source.testutils.BucketAccessor;
+import io.aiven.kafka.connect.s3.source.utils.S3OffsetManagerEntry;
 import io.aiven.kafka.connect.s3.source.utils.S3SourceRecord;
 import io.aiven.kafka.connect.s3.source.utils.SourceRecordIterator;
 
@@ -175,8 +175,10 @@ final class S3SourceTaskTest {
     }
 
     private static S3SourceRecord getAivenS3SourceRecord() {
-        S3OffsetManagerEntry offsetManagerEntry = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "testtopic", 0);
-        return new S3SourceRecord(offsetManagerEntry, "mock-key".getBytes(StandardCharsets.UTF_8), "mock-value".getBytes(StandardCharsets.UTF_8));
+        final S3OffsetManagerEntry offsetManagerEntry = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "testtopic",
+                0);
+        return new S3SourceRecord(offsetManagerEntry, "mock-key".getBytes(StandardCharsets.UTF_8),
+                "mock-value".getBytes(StandardCharsets.UTF_8));
     }
 
     @SuppressWarnings("PMD.AvoidAccessibilityAlteration")

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/input/ByteArrayTransformerTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/input/ByteArrayTransformerTest.java
@@ -55,7 +55,6 @@ final class ByteArrayTransformerTest {
 
         final Stream<Object> records = byteArrayTransformer.getRecords(inputStreamIOSupplier, TEST_TOPIC, 0,
                 s3SourceConfig);
-
         final List<Object> recs = records.collect(Collectors.toList());
         assertThat(recs).hasSize(1);
         assertThat((byte[]) recs.get(0)).isEqualTo(data);

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/FileReaderTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/FileReaderTest.java
@@ -105,6 +105,7 @@ class FileReaderTest {
 
         // assigned 1 object to taskid
         assertThat(summaries).hasNext();
+
         assertThat(summaries.next().getSize()).isEqualTo(1);
         assertThat(summaries).isExhausted();
     }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/OffsetManagerTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/OffsetManagerTest.java
@@ -19,11 +19,9 @@ package io.aiven.kafka.connect.s3.source.utils;
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.TARGET_TOPICS;
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.TARGET_TOPIC_PARTITIONS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,21 +31,16 @@ import org.apache.kafka.connect.storage.OffsetStorageReader;
 
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
 final class OffsetManagerTest {
 
     private Map<String, String> properties;
     private static final String TEST_BUCKET = "test-bucket";
 
-    @Mock
-    private SourceTaskContext sourceTaskContext;
-
     private S3SourceConfig s3SourceConfig;
-
-    private OffsetManager offsetManager;
 
     @BeforeEach
     public void setUp() {
@@ -58,7 +51,7 @@ final class OffsetManagerTest {
 
     @Test
     void testWithOffsets() {
-        sourceTaskContext = mock(SourceTaskContext.class);
+        final SourceTaskContext sourceTaskContext = mock(SourceTaskContext.class);
         final OffsetStorageReader offsetStorageReader = mock(OffsetStorageReader.class);
         when(sourceTaskContext.offsetStorageReader()).thenReturn(offsetStorageReader);
 
@@ -74,7 +67,7 @@ final class OffsetManagerTest {
 
         when(offsetStorageReader.offsets(any())).thenReturn(offsets);
 
-        offsetManager = new OffsetManager(sourceTaskContext, s3SourceConfig);
+        final OffsetManager offsetManager = new OffsetManager(sourceTaskContext, s3SourceConfig);
 
         final Map<Map<String, Object>, Map<String, Object>> retrievedOffsets = offsetManager.getOffsets();
         assertThat(retrievedOffsets.size()).isEqualTo(1);
@@ -83,20 +76,21 @@ final class OffsetManagerTest {
 
     @Test
     void testUpdateCurrentOffsets() {
-        TestingManagerEntry offsetEntry = new TestingManagerEntry("bucket", "topic1", 0);
+        final TestingManagerEntry offsetEntry = new TestingManagerEntry("bucket", "topic1", 0);
 
         final Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
         offsets.put(offsetEntry.getManagerKey().getPartitionMap(), offsetEntry.getProperties());
 
-        OffsetManager underTest = new OffsetManager(offsets);
+        final OffsetManager underTest = new OffsetManager(offsets);
 
         offsetEntry.setProperty("MyProperty", "WOW");
 
         underTest.updateCurrentOffsets(offsetEntry);
 
-        Map<Map<String, Object>, Map<String, Object>> offsetMap = underTest.getOffsets();
-        assertTrue(offsetMap.containsKey(offsetEntry.getManagerKey().getPartitionMap()));
-        TestingManagerEntry stored = offsetEntry.fromProperties(offsetMap.get(offsetEntry.getManagerKey().getPartitionMap()));
+        final Map<Map<String, Object>, Map<String, Object>> offsetMap = underTest.getOffsets();
+        assertThat(offsetMap.containsKey(offsetEntry.getManagerKey().getPartitionMap())).isTrue();
+        final TestingManagerEntry stored = offsetEntry
+                .fromProperties(offsetMap.get(offsetEntry.getManagerKey().getPartitionMap()));
         assertThat(stored.getManagerKey().getPartitionMap()).isEqualTo(offsetEntry.getManagerKey().getPartitionMap());
         assertThat(stored.properties).isEqualTo(offsetEntry.properties);
     }
@@ -104,16 +98,15 @@ final class OffsetManagerTest {
     @Test
     void updateCurrentOffsetsTestNewEntry() {
 
-        final Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
-        OffsetManager underTest = new OffsetManager(new HashMap<>());
+        final OffsetManager underTest = new OffsetManager(new HashMap<>());
 
-
-        TestingManagerEntry offsetEntry = new TestingManagerEntry("bucket", "topic1", 0);
+        final TestingManagerEntry offsetEntry = new TestingManagerEntry("bucket", "topic1", 0);
         underTest.updateCurrentOffsets(offsetEntry);
 
-        Map<Map<String, Object>, Map<String, Object>> offsetMap = underTest.getOffsets();
-        assertTrue(offsetMap.containsKey(offsetEntry.getManagerKey().getPartitionMap()));
-        TestingManagerEntry stored = offsetEntry.fromProperties(offsetMap.get(offsetEntry.getManagerKey().getPartitionMap()));
+        final Map<Map<String, Object>, Map<String, Object>> offsetMap = underTest.getOffsets();
+        assertThat(offsetMap.containsKey(offsetEntry.getManagerKey().getPartitionMap())).isTrue();
+        final TestingManagerEntry stored = offsetEntry
+                .fromProperties(offsetMap.get(offsetEntry.getManagerKey().getPartitionMap()));
         assertThat(stored.getManagerKey().getPartitionMap()).isEqualTo(offsetEntry.getManagerKey().getPartitionMap());
         assertThat(stored.properties).isEqualTo(offsetEntry.properties);
 
@@ -122,21 +115,19 @@ final class OffsetManagerTest {
     @Test
     void updateCurrentOffsetsDataNotLost() {
 
-        final Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
-        OffsetManager underTest = new OffsetManager(new HashMap<>());
+        final OffsetManager underTest = new OffsetManager(new HashMap<>());
 
-
-        TestingManagerEntry offsetEntry = new TestingManagerEntry("bucket", "topic1", 0);
+        final TestingManagerEntry offsetEntry = new TestingManagerEntry("bucket", "topic1", 0);
         offsetEntry.setProperty("test", "WOW");
         underTest.updateCurrentOffsets(offsetEntry);
 
-        TestingManagerEntry offsetEntry2 = new TestingManagerEntry("bucket", "topic1", 0);
         offsetEntry.setProperty("test2", "a thing");
         underTest.updateCurrentOffsets(offsetEntry);
 
-        Map<Map<String, Object>, Map<String, Object>> offsetMap = underTest.getOffsets();
-        assertTrue(offsetMap.containsKey(offsetEntry.getManagerKey().getPartitionMap()));
-        TestingManagerEntry stored = offsetEntry.fromProperties(offsetMap.get(offsetEntry.getManagerKey().getPartitionMap()));
+        final Map<Map<String, Object>, Map<String, Object>> offsetMap = underTest.getOffsets();
+        assertThat(offsetMap.containsKey(offsetEntry.getManagerKey().getPartitionMap())).isTrue();
+        final TestingManagerEntry stored = offsetEntry
+                .fromProperties(offsetMap.get(offsetEntry.getManagerKey().getPartitionMap()));
         assertThat(stored.getManagerKey().getPartitionMap()).isEqualTo(offsetEntry.getManagerKey().getPartitionMap());
         assertThat(stored.properties.get("test")).isEqualTo("WOW");
         assertThat(stored.properties.get("test2")).isEqualTo("a thing");
@@ -148,18 +139,30 @@ final class OffsetManagerTest {
         properties.put(TARGET_TOPICS, "topic1,topic2");
     }
 
-    private static class TestingManagerEntry implements OffsetManager.OffsetManagerEntry<TestingManagerEntry> {
+    private static class TestingManagerEntry implements OffsetManager.OffsetManagerEntry<TestingManagerEntry> { // NOPMD
+                                                                                                                // this
+                                                                                                                // is
+                                                                                                                // not a
+                                                                                                                // test
+                                                                                                                // class
+                                                                                                                // it is
+                                                                                                                // a
+                                                                                                                // helper
+                                                                                                                // for
+                                                                                                                // the
+                                                                                                                // unit
+                                                                                                                // tests
         final Map<String, Object> properties = new HashMap<>();
 
-        TestingManagerEntry(String bucket, String topic, int partition) {
+        TestingManagerEntry(final String bucket, final String topic, final int partition) {
             properties.put("topic", topic);
             properties.put("partition", partition);
             properties.put("bucket", bucket);
         }
 
         @Override
-        public TestingManagerEntry fromProperties(Map<String, Object> properties) {
-            TestingManagerEntry result = new TestingManagerEntry(null, null, 0);
+        public TestingManagerEntry fromProperties(final Map<String, Object> properties) {
+            final TestingManagerEntry result = new TestingManagerEntry(null, null, 0);
             result.properties.clear();
             result.properties.putAll(properties);
             return result;
@@ -171,12 +174,12 @@ final class OffsetManagerTest {
         }
 
         @Override
-        public Object getProperty(String key) {
+        public Object getProperty(final String key) {
             return properties.get(key);
         }
 
         @Override
-        public void setProperty(String key, Object value) {
+        public void setProperty(final String key, final Object value) {
             properties.put(key, value);
         }
 
@@ -185,13 +188,15 @@ final class OffsetManagerTest {
             return new OffsetManager.OffsetManagerKey() {
                 @Override
                 public Map<String, Object> getPartitionMap() {
-                    return Map.of("topic", properties.get("topic"), "partition", properties.get("topic"), "bucket", properties.get("bucket"));
+                    return Map.of("topic", properties.get("topic"), "partition", properties.get("topic"), "bucket",
+                            properties.get("bucket"));
                 }
             };
         }
 
         @Override
-        public int compareTo(TestingManagerEntry other) {
+        @SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
+        public int compareTo(final TestingManagerEntry other) {
             int result = ((String) getProperty("bucket")).compareTo((String) other.getProperty("bucket"));
             if (result == 0) {
                 result = ((String) getProperty("topic")).compareTo((String) other.getProperty("topic"));

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/OffsetManagerTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/OffsetManagerTest.java
@@ -16,17 +16,15 @@
 
 package io.aiven.kafka.connect.s3.source.utils;
 
-import static io.aiven.kafka.connect.s3.source.S3SourceTask.OBJECT_KEY;
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.TARGET_TOPICS;
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.TARGET_TOPIC_PARTITIONS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.offset;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -173,6 +171,11 @@ final class OffsetManagerTest {
         }
 
         @Override
+        public Object getProperty(String key) {
+            return properties.get(key);
+        }
+
+        @Override
         public void setProperty(String key, Object value) {
             properties.put(key, value);
         }
@@ -185,6 +188,18 @@ final class OffsetManagerTest {
                     return Map.of("topic", properties.get("topic"), "partition", properties.get("topic"), "bucket", properties.get("bucket"));
                 }
             };
+        }
+
+        @Override
+        public int compareTo(TestingManagerEntry other) {
+            int result = ((String) getProperty("bucket")).compareTo((String) other.getProperty("bucket"));
+            if (result == 0) {
+                result = ((String) getProperty("topic")).compareTo((String) other.getProperty("topic"));
+                if (result == 0) {
+                    result = ((String) getProperty("partition")).compareTo((String) other.getProperty("partition"));
+                }
+            }
+            return result;
         }
     }
 }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/RecordProcessorTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/RecordProcessorTest.java
@@ -18,7 +18,6 @@ package io.aiven.kafka.connect.s3.source.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -28,7 +27,6 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 import java.net.ConnectException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -94,8 +92,9 @@ class RecordProcessorTest {
     void testProcessRecordsWithRecords() throws ConnectException {
         when(s3SourceConfig.getInt(S3SourceConfig.MAX_POLL_RECORDS)).thenReturn(5);
         when(sourceRecordIterator.hasNext()).thenReturn(true, false); // One iteration with records
+        when(valueConverter.toConnectData(any(), any())).thenReturn(new SchemaAndValue(null, "Converted value".getBytes(StandardCharsets.UTF_8)));
 
-        S3OffsetManagerEntry offsetManagerEntry = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "topic", 1);
+        final S3OffsetManagerEntry offsetManagerEntry = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "topic", 1);
         final S3SourceRecord s3SourceRecord = new S3SourceRecord(offsetManagerEntry, new byte[0], new byte[0]);
         when(sourceRecordIterator.next()).thenReturn(s3SourceRecord);
 

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/RecordProcessorTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/RecordProcessorTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.storage.Converter;
 
+import io.aiven.kafka.connect.common.source.offsets.OffsetManager;
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapperTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapperTest.java
@@ -99,7 +99,7 @@ class S3ObjectToSourceRecordMapperTest {
         return new S3ObjectToSourceRecordMapper(new TestingTransformer() {
             @Override
             public Stream<Object> getRecords(final IOSupplier<InputStream> inputStream, final String topic,
-                                             final int topicPartition, final S3SourceConfig s3SourceConfig) {
+                    final int topicPartition, final S3SourceConfig s3SourceConfig) {
                 final Stream<Object> streamResult = super.getRecords(inputStream, topic, topicPartition,
                         s3SourceConfig);
                 final List<Object> res = streamResult.collect(Collectors.toList());
@@ -139,7 +139,7 @@ class S3ObjectToSourceRecordMapperTest {
         underTest = singleRecordMapper(new TestingTransformer() {
             @Override
             public Stream<Object> getRecords(final IOSupplier<InputStream> inputStream, final String topic,
-                                             final int topicPartition, final S3SourceConfig s3SourceConfig) {
+                    final int topicPartition, final S3SourceConfig s3SourceConfig) {
                 throw new ConnectException("BOOM!");
             }
         });

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapperTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapperTest.java
@@ -29,8 +29,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.errors.ConnectException;
 
+import io.aiven.kafka.connect.common.source.offsets.OffsetManager;
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 
@@ -99,7 +101,7 @@ class S3ObjectToSourceRecordMapperTest {
         return new S3ObjectToSourceRecordMapper(new TestingTransformer() {
             @Override
             public Stream<Object> getRecords(final IOSupplier<InputStream> inputStream, final String topic,
-                    final int topicPartition, final S3SourceConfig s3SourceConfig) {
+                    final int topicPartition, final AbstractConfig s3SourceConfig) {
                 final Stream<Object> streamResult = super.getRecords(inputStream, topic, topicPartition,
                         s3SourceConfig);
                 final List<Object> res = streamResult.collect(Collectors.toList());
@@ -139,7 +141,7 @@ class S3ObjectToSourceRecordMapperTest {
         underTest = singleRecordMapper(new TestingTransformer() {
             @Override
             public Stream<Object> getRecords(final IOSupplier<InputStream> inputStream, final String topic,
-                    final int topicPartition, final S3SourceConfig s3SourceConfig) {
+                    final int topicPartition, final AbstractConfig s3SourceConfig) {
                 throw new ConnectException("BOOM!");
             }
         });

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapperTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapperTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.source.utils;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+import io.aiven.kafka.connect.s3.source.input.Transformer;
+
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import org.apache.commons.io.function.IOSupplier;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class S3ObjectToSourceRecordMapperTest {
+
+    private Transformer transformer;
+
+    private S3SourceConfig s3SourceConfig;
+
+    private TopicPartitionExtractingPredicate topicPartitionExtractingPredicate;
+
+    private OffsetManager offsetManager;
+
+    private S3ObjectToSourceRecordMapper underTest;
+
+    private S3OffsetManagerEntry offsetManagerEntry;
+
+    private S3Object s3Object = mock(S3Object.class);
+
+    @BeforeEach
+    public void setUp() {
+        transformer = mock(Transformer.class);
+        topicPartitionExtractingPredicate = mock(TopicPartitionExtractingPredicate.class);
+        offsetManagerEntry = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "topic", 1);
+        when(topicPartitionExtractingPredicate.getOffsetMapEntry()).thenReturn(offsetManagerEntry);
+        s3SourceConfig = mock(S3SourceConfig.class);
+        s3Object = mock(S3Object.class);
+        when(s3Object.getKey()).thenReturn("s3ObjectKey");
+        offsetManager = mock(OffsetManager.class);
+    }
+
+    @Test
+    void noS3ObjectContentContentTest() {
+        underTest = new S3ObjectToSourceRecordMapper(transformer, topicPartitionExtractingPredicate, s3SourceConfig,
+                offsetManager);
+        Iterator<S3SourceRecord> result = underTest.apply(s3Object);
+        assertFalse(result.hasNext());
+    }
+
+    void assertS3RecordMatches(S3SourceRecord s3SourceRecord, String key, String value) {
+        assertArrayEquals(key.getBytes(StandardCharsets.UTF_8), s3SourceRecord.getRecordKey(), key);
+        assertArrayEquals(value.getBytes(StandardCharsets.UTF_8), s3SourceRecord.getRecordValue(), value);
+    }
+
+    private S3ObjectToSourceRecordMapper singleRecordMapper(final Transformer transformer) {
+        S3ObjectInputStream inputStream = new S3ObjectInputStream(
+                new ByteArrayInputStream("Original value".getBytes(StandardCharsets.UTF_8)),
+                mock(HttpRequestBase.class));
+        when(s3Object.getObjectContent()).thenReturn(inputStream);
+        return new S3ObjectToSourceRecordMapper(transformer, topicPartitionExtractingPredicate, s3SourceConfig,
+                offsetManager);
+    }
+
+    private S3ObjectToSourceRecordMapper doubleRecordMapper() {
+        S3ObjectInputStream inputStream = new S3ObjectInputStream(
+                new ByteArrayInputStream("Original value".getBytes(StandardCharsets.UTF_8)),
+                mock(HttpRequestBase.class));
+        when(s3Object.getObjectContent()).thenReturn(inputStream);
+        return new S3ObjectToSourceRecordMapper(new TestingTransformer() {
+            @Override
+            public Stream<Object> getRecords(IOSupplier<InputStream> inputStream, String topic, int topicPartition,
+                    S3SourceConfig s3SourceConfig) {
+                Stream<Object> result = super.getRecords(inputStream, topic, topicPartition, s3SourceConfig);
+                List<Object> list = result.collect(Collectors.toList());
+                list.add("Transformed2");
+                return list.stream();
+            }
+        }, topicPartitionExtractingPredicate, s3SourceConfig, offsetManager);
+    }
+
+    @Test
+    void singleRecordTest() {
+        underTest = singleRecordMapper(new TestingTransformer());
+        Iterator<S3SourceRecord> result = underTest.apply(s3Object);
+        assertTrue(result.hasNext());
+        S3SourceRecord s3SourceRecord = result.next();
+        assertS3RecordMatches(s3SourceRecord, "s3ObjectKey", "Transformed(Original value)");
+        assertEquals(1L, offsetManagerEntry.getRecordCount());
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    void multipleRecordTest() {
+        underTest = doubleRecordMapper();
+        Iterator<S3SourceRecord> result = underTest.apply(s3Object);
+        assertTrue(result.hasNext());
+        S3SourceRecord s3SourceRecord = result.next();
+        assertS3RecordMatches(s3SourceRecord, "s3ObjectKey", "Transformed(Original value)");
+        assertEquals(1L, offsetManagerEntry.getRecordCount());
+        assertTrue(result.hasNext());
+        s3SourceRecord = result.next();
+        assertS3RecordMatches(s3SourceRecord, "s3ObjectKey", "Transformed2");
+        assertEquals(2L, offsetManagerEntry.getRecordCount());
+    }
+
+    @Test
+    void transformerRuntimeExceptionTest() {
+        underTest = singleRecordMapper(new TestingTransformer() {
+            @Override
+            public Stream<Object> getRecords(IOSupplier<InputStream> inputStream, String topic, int topicPartition,
+                    S3SourceConfig s3SourceConfig) {
+                throw new RuntimeException("BOOM!");
+            }
+        });
+        Iterator<S3SourceRecord> result = underTest.apply(s3Object);
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    void transformerIOExceptionTest() {
+        InputStream baseInputStream = new ByteArrayInputStream("Original value".getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public void close() throws IOException {
+                throw new IOException("BOOM!");
+            }
+        };
+        S3ObjectInputStream inputStream = new S3ObjectInputStream(baseInputStream, mock(HttpRequestBase.class));
+        when(s3Object.getObjectContent()).thenReturn(inputStream);
+        underTest = new S3ObjectToSourceRecordMapper(transformer, topicPartitionExtractingPredicate, s3SourceConfig,
+                offsetManager);
+        underTest = singleRecordMapper(new TestingTransformer());
+        Iterator<S3SourceRecord> result = underTest.apply(s3Object);
+        assertTrue(result.hasNext());
+        S3SourceRecord s3SourceRecord = result.next();
+        assertS3RecordMatches(s3SourceRecord, "s3ObjectKey", "Transformed(Original value)");
+        assertEquals(1L, offsetManagerEntry.getRecordCount());
+        assertFalse(result.hasNext());
+    }
+}

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapperTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3ObjectToSourceRecordMapperTest.java
@@ -16,10 +16,7 @@
 
 package io.aiven.kafka.connect.s3.source.utils;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +29,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.kafka.connect.errors.ConnectException;
+
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 
@@ -42,7 +41,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class S3ObjectToSourceRecordMapperTest {
+class S3ObjectToSourceRecordMapperTest {
 
     private Transformer transformer;
 
@@ -63,7 +62,7 @@ public class S3ObjectToSourceRecordMapperTest {
         transformer = mock(Transformer.class);
         topicPartitionExtractingPredicate = mock(TopicPartitionExtractingPredicate.class);
         offsetManagerEntry = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "topic", 1);
-        when(topicPartitionExtractingPredicate.getOffsetMapEntry()).thenReturn(offsetManagerEntry);
+        when(topicPartitionExtractingPredicate.getOffsetMnagerEntry()).thenReturn(offsetManagerEntry);
         s3SourceConfig = mock(S3SourceConfig.class);
         s3Object = mock(S3Object.class);
         when(s3Object.getKey()).thenReturn("s3ObjectKey");
@@ -74,17 +73,17 @@ public class S3ObjectToSourceRecordMapperTest {
     void noS3ObjectContentContentTest() {
         underTest = new S3ObjectToSourceRecordMapper(transformer, topicPartitionExtractingPredicate, s3SourceConfig,
                 offsetManager);
-        Iterator<S3SourceRecord> result = underTest.apply(s3Object);
-        assertFalse(result.hasNext());
+        final Iterator<S3SourceRecord> result = underTest.apply(s3Object);
+        assertThat(result.hasNext()).isFalse();
     }
 
-    void assertS3RecordMatches(S3SourceRecord s3SourceRecord, String key, String value) {
-        assertArrayEquals(key.getBytes(StandardCharsets.UTF_8), s3SourceRecord.getRecordKey(), key);
-        assertArrayEquals(value.getBytes(StandardCharsets.UTF_8), s3SourceRecord.getRecordValue(), value);
+    void assertS3RecordMatches(final S3SourceRecord s3SourceRecord, final String key, final String value) {
+        assertThat(s3SourceRecord.getRecordKey()).isEqualTo(key.getBytes(StandardCharsets.UTF_8));
+        assertThat(s3SourceRecord.getRecordValue()).isEqualTo(value.getBytes(StandardCharsets.UTF_8));
     }
 
     private S3ObjectToSourceRecordMapper singleRecordMapper(final Transformer transformer) {
-        S3ObjectInputStream inputStream = new S3ObjectInputStream(
+        final S3ObjectInputStream inputStream = new S3ObjectInputStream(
                 new ByteArrayInputStream("Original value".getBytes(StandardCharsets.UTF_8)),
                 mock(HttpRequestBase.class));
         when(s3Object.getObjectContent()).thenReturn(inputStream);
@@ -93,18 +92,19 @@ public class S3ObjectToSourceRecordMapperTest {
     }
 
     private S3ObjectToSourceRecordMapper doubleRecordMapper() {
-        S3ObjectInputStream inputStream = new S3ObjectInputStream(
+        final S3ObjectInputStream inputStream = new S3ObjectInputStream(
                 new ByteArrayInputStream("Original value".getBytes(StandardCharsets.UTF_8)),
                 mock(HttpRequestBase.class));
         when(s3Object.getObjectContent()).thenReturn(inputStream);
         return new S3ObjectToSourceRecordMapper(new TestingTransformer() {
             @Override
-            public Stream<Object> getRecords(IOSupplier<InputStream> inputStream, String topic, int topicPartition,
-                    S3SourceConfig s3SourceConfig) {
-                Stream<Object> result = super.getRecords(inputStream, topic, topicPartition, s3SourceConfig);
-                List<Object> list = result.collect(Collectors.toList());
-                list.add("Transformed2");
-                return list.stream();
+            public Stream<Object> getRecords(final IOSupplier<InputStream> inputStream, final String topic,
+                                             final int topicPartition, final S3SourceConfig s3SourceConfig) {
+                final Stream<Object> streamResult = super.getRecords(inputStream, topic, topicPartition,
+                        s3SourceConfig);
+                final List<Object> res = streamResult.collect(Collectors.toList());
+                res.add("Transformed2");
+                return res.stream();
             }
         }, topicPartitionExtractingPredicate, s3SourceConfig, offsetManager);
     }
@@ -112,59 +112,60 @@ public class S3ObjectToSourceRecordMapperTest {
     @Test
     void singleRecordTest() {
         underTest = singleRecordMapper(new TestingTransformer());
-        Iterator<S3SourceRecord> result = underTest.apply(s3Object);
-        assertTrue(result.hasNext());
-        S3SourceRecord s3SourceRecord = result.next();
+        final Iterator<S3SourceRecord> result = underTest.apply(s3Object);
+        assertThat(result).hasNext();
+        final S3SourceRecord s3SourceRecord = result.next();
         assertS3RecordMatches(s3SourceRecord, "s3ObjectKey", "Transformed(Original value)");
-        assertEquals(1L, offsetManagerEntry.getRecordCount());
-        assertFalse(result.hasNext());
+        assertThat(offsetManagerEntry.getRecordCount()).isEqualTo(1L);
+        assertThat(result.hasNext()).isFalse();
     }
 
     @Test
     void multipleRecordTest() {
         underTest = doubleRecordMapper();
-        Iterator<S3SourceRecord> result = underTest.apply(s3Object);
-        assertTrue(result.hasNext());
+        final Iterator<S3SourceRecord> result = underTest.apply(s3Object);
+        assertThat(result).hasNext();
         S3SourceRecord s3SourceRecord = result.next();
         assertS3RecordMatches(s3SourceRecord, "s3ObjectKey", "Transformed(Original value)");
-        assertEquals(1L, offsetManagerEntry.getRecordCount());
-        assertTrue(result.hasNext());
+        assertThat(offsetManagerEntry.getRecordCount()).isEqualTo(1L);
+        assertThat(result).hasNext();
         s3SourceRecord = result.next();
         assertS3RecordMatches(s3SourceRecord, "s3ObjectKey", "Transformed2");
-        assertEquals(2L, offsetManagerEntry.getRecordCount());
+        assertThat(offsetManagerEntry.getRecordCount()).isEqualTo(2L);
     }
 
     @Test
     void transformerRuntimeExceptionTest() {
         underTest = singleRecordMapper(new TestingTransformer() {
             @Override
-            public Stream<Object> getRecords(IOSupplier<InputStream> inputStream, String topic, int topicPartition,
-                    S3SourceConfig s3SourceConfig) {
-                throw new RuntimeException("BOOM!");
+            public Stream<Object> getRecords(final IOSupplier<InputStream> inputStream, final String topic,
+                                             final int topicPartition, final S3SourceConfig s3SourceConfig) {
+                throw new ConnectException("BOOM!");
             }
         });
-        Iterator<S3SourceRecord> result = underTest.apply(s3Object);
-        assertFalse(result.hasNext());
+        final Iterator<S3SourceRecord> result = underTest.apply(s3Object);
+        assertThat(result.hasNext()).isFalse();
     }
 
     @Test
     void transformerIOExceptionTest() {
-        InputStream baseInputStream = new ByteArrayInputStream("Original value".getBytes(StandardCharsets.UTF_8)) {
+        final InputStream baseInputStream = new ByteArrayInputStream( // NOPMD
+                "Original value".getBytes(StandardCharsets.UTF_8)) {
             @Override
             public void close() throws IOException {
                 throw new IOException("BOOM!");
             }
         };
-        S3ObjectInputStream inputStream = new S3ObjectInputStream(baseInputStream, mock(HttpRequestBase.class));
+        final S3ObjectInputStream inputStream = new S3ObjectInputStream(baseInputStream, mock(HttpRequestBase.class)); // NOPMD
         when(s3Object.getObjectContent()).thenReturn(inputStream);
         underTest = new S3ObjectToSourceRecordMapper(transformer, topicPartitionExtractingPredicate, s3SourceConfig,
                 offsetManager);
         underTest = singleRecordMapper(new TestingTransformer());
-        Iterator<S3SourceRecord> result = underTest.apply(s3Object);
-        assertTrue(result.hasNext());
-        S3SourceRecord s3SourceRecord = result.next();
+        final Iterator<S3SourceRecord> result = underTest.apply(s3Object);
+        assertThat(result).hasNext();
+        final S3SourceRecord s3SourceRecord = result.next();
         assertS3RecordMatches(s3SourceRecord, "s3ObjectKey", "Transformed(Original value)");
-        assertEquals(1L, offsetManagerEntry.getRecordCount());
-        assertFalse(result.hasNext());
+        assertThat(offsetManagerEntry.getRecordCount()).isEqualTo(1L);
+        assertThat(result.hasNext()).isFalse();
     }
 }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntryTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntryTest.java
@@ -25,18 +25,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
+@SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_INFERRED", justification = "Ignores return value as we expect an exception")
 class S3OffsetManagerEntryTest {
 
-    private static final String  DFLT_BUCKET = "bucket";
-    private static final String  DFLT_KEY = "s3ObjectKey";
-    private static final String  DFLT_TOPIC = "topic";
-    private static final int  DFLT_PARTITION = 1;
+    private static final String DFLT_BUCKET = "bucket";
+    private static final String DFLT_KEY = "s3ObjectKey";
+    private static final String DFLT_TOPIC = "topic";
+    private static final int DFLT_PARTITION = 1;
 
     private S3OffsetManagerEntry underTest;
     @BeforeEach
@@ -63,11 +64,16 @@ class S3OffsetManagerEntryTest {
     void testSetProperty() {
         underTest.setProperty("Foo", "bar");
         assertThat(underTest.getProperties().get("Foo")).isEqualTo("bar");
-        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.BUCKET, "someValue")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.OBJECT_KEY, "someValue")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.TOPIC, "someValue")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.PARTITION, "someValue")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.RECORD_COUNT, "someValue")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.BUCKET, "someValue"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.OBJECT_KEY, "someValue"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.TOPIC, "someValue"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.PARTITION, "someValue"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.RECORD_COUNT, "someValue"))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -78,20 +84,21 @@ class S3OffsetManagerEntryTest {
         assertThat(underTest.getRecordCount()).isEqualTo(0L);
     }
 
-
-    public void testFromProperties() {
+    @Test
+    void testFromProperties() {
         assertThat(underTest.fromProperties(underTest.getProperties()).compareTo(underTest)).isEqualTo(0);
         assertThat(underTest.fromProperties(null)).isNull();
     }
 
     @ParameterizedTest(name = "{index} {0}")
     @MethodSource("fromPropertiesThrowingExceptionData")
-    public void testFromPropertiesThrowingException(String name, Map<String, Object> map, Class<?> expected) {
-        assertThatThrownBy(() -> underTest.fromProperties(map)).isInstanceOf(expected).as(name+" does not throw exception: "+expected.getName());
+    void testFromPropertiesThrowingException(final String name, final Map<String, Object> map,
+            final Class<?> expected) {
+        assertThatThrownBy(() -> underTest.fromProperties(map)).isInstanceOf(expected);
     }
 
     private static Map<String, Object> createPopulatedMap() {
-        Map<String, Object> map = new HashMap<>();
+        final Map<String, Object> map = new HashMap<>();
         map.put(S3OffsetManagerEntry.BUCKET, DFLT_BUCKET);
         map.put(S3OffsetManagerEntry.OBJECT_KEY, DFLT_KEY);
         map.put(S3OffsetManagerEntry.TOPIC, DFLT_TOPIC);
@@ -100,11 +107,12 @@ class S3OffsetManagerEntryTest {
         return map;
     }
     private static Stream<Arguments> fromPropertiesThrowingExceptionData() {
-        String[] fields = {S3OffsetManagerEntry.BUCKET, S3OffsetManagerEntry.OBJECT_KEY, S3OffsetManagerEntry.TOPIC, S3OffsetManagerEntry.PARTITION, S3OffsetManagerEntry.RECORD_COUNT};
-        List<Arguments> lst = new ArrayList<>();
+        final String[] fields = { S3OffsetManagerEntry.BUCKET, S3OffsetManagerEntry.OBJECT_KEY,
+                S3OffsetManagerEntry.TOPIC, S3OffsetManagerEntry.PARTITION, S3OffsetManagerEntry.RECORD_COUNT };
+        final List<Arguments> lst = new ArrayList<>();
 
-        for (String field : fields) {
-            Map<String, Object> map = createPopulatedMap();
+        for (final String field : fields) {
+            final Map<String, Object> map = createPopulatedMap();
             map.remove(field);
             lst.add(Arguments.of("Missing " + field, map, IllegalArgumentException.class));
         }
@@ -113,30 +121,39 @@ class S3OffsetManagerEntryTest {
 
     @ParameterizedTest(name = "{index} {0}")
     @MethodSource("compareToData")
-    void testCompareTo(String name, S3OffsetManagerEntry other, int value) {
-        assertThat(other.compareTo(underTest)).as("Failure in "+name).isEqualTo(value);
+    void testCompareTo(final String name, final S3OffsetManagerEntry other, final int value) {
+        assertThat(other.compareTo(underTest)).as("Failure in " + name).isEqualTo(value);
     }
 
     private static Stream<Arguments> compareToData() {
-        List<Arguments> lst = new ArrayList<>();
+        final List<Arguments> lst = new ArrayList<>();
 
-        lst.add(Arguments.of("Same values", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION), 0));
-        lst.add(Arguments.of("Bucket before", new S3OffsetManagerEntry(DFLT_BUCKET.substring(0, DFLT_BUCKET.length()-1), DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION), -1));
-        lst.add(Arguments.of("Bucket after", new S3OffsetManagerEntry(DFLT_BUCKET+"5", DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION), 1));
-        lst.add(Arguments.of("Key before", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY.substring(0, DFLT_KEY.length()-1), DFLT_TOPIC, DFLT_PARTITION), -1));
-        lst.add(Arguments.of("Key after", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY+"5", DFLT_TOPIC, DFLT_PARTITION), 1));
-        lst.add(Arguments.of("Topic before", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC.substring(0, DFLT_TOPIC.length()-1), DFLT_PARTITION), -1));
-        lst.add(Arguments.of("Topic after", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC+"5", DFLT_PARTITION), 1));
-        lst.add(Arguments.of("Partition before", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION-1), -1));
-        lst.add(Arguments.of("Partition after", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION+1), 1));
+        lst.add(Arguments.of("Same values", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION),
+                0));
+        lst.add(Arguments.of("Bucket before", new S3OffsetManagerEntry(
+                DFLT_BUCKET.substring(0, DFLT_BUCKET.length() - 1), DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION), -1));
+        lst.add(Arguments.of("Bucket after",
+                new S3OffsetManagerEntry(DFLT_BUCKET + "5", DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION), 1));
+        lst.add(Arguments.of("Key before", new S3OffsetManagerEntry(DFLT_BUCKET,
+                DFLT_KEY.substring(0, DFLT_KEY.length() - 1), DFLT_TOPIC, DFLT_PARTITION), -1));
+        lst.add(Arguments.of("Key after",
+                new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY + "5", DFLT_TOPIC, DFLT_PARTITION), 1));
+        lst.add(Arguments.of("Topic before", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY,
+                DFLT_TOPIC.substring(0, DFLT_TOPIC.length() - 1), DFLT_PARTITION), -1));
+        lst.add(Arguments.of("Topic after",
+                new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC + "5", DFLT_PARTITION), 1));
+        lst.add(Arguments.of("Partition before",
+                new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION - 1), -1));
+        lst.add(Arguments.of("Partition after",
+                new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION + 1), 1));
 
         S3OffsetManagerEntry entry = new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION);
-        Map<String, Object> map = entry.getProperties();
+        final Map<String, Object> map = entry.getProperties();
         map.put(S3OffsetManagerEntry.RECORD_COUNT, -1L);
         entry = entry.fromProperties(map);
         lst.add(Arguments.of("Record count before", entry, -1));
 
-         entry = new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION);
+        entry = new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION);
         entry.incrementRecordCount();
         lst.add(Arguments.of("Record count after", entry, 1));
         return lst.stream();

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntryTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntryTest.java
@@ -87,7 +87,7 @@ class S3OffsetManagerEntryTest {
     @ParameterizedTest(name = "{index} {0}")
     @MethodSource("fromPropertiesThrowingExceptionData")
     public void testFromPropertiesThrowingException(String name, Map<String, Object> map, Class<?> expected) {
-        assertThatThrownBy(() -> underTest.fromProperties(map)).as(name+" does not throw exception: "+expected.getName()).isInstanceOf(expected);
+        assertThatThrownBy(() -> underTest.fromProperties(map)).isInstanceOf(expected).as(name+" does not throw exception: "+expected.getName());
     }
 
     private static Map<String, Object> createPopulatedMap() {

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntryTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntryTest.java
@@ -1,14 +1,30 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.s3.source.utils;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class S3OffsetManagerEntryTest {
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class S3OffsetManagerEntryTest {
 
     private S3OffsetManagerEntry underTest;
     @BeforeEach
@@ -16,9 +32,9 @@ public class S3OffsetManagerEntryTest {
         underTest = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "topic", 1);
     }
     @Test
-    public void testConstructorExpressedInMaps() {
+    void testConstructorExpressedInMaps() {
 
-        Map<String,Object> map = underTest.getProperties();
+        Map<String, Object> map = underTest.getProperties();
         assertThat(map.get(S3OffsetManagerEntry.BUCKET)).isEqualTo("bucket");
         assertThat(map.get(S3OffsetManagerEntry.OBJECT_KEY)).isEqualTo("s3ObjectKey");
         assertThat(map.get(S3OffsetManagerEntry.TOPIC)).isEqualTo("topic");
@@ -32,18 +48,23 @@ public class S3OffsetManagerEntryTest {
     }
 
     @Test
-    public void testSetProperty() {
+    void testSetProperty() {
         underTest.setProperty("Foo", "bar");
         assertThat(underTest.getProperties().get("Foo")).isEqualTo("bar");
-        assertThrows( IllegalArgumentException.class, () -> underTest.setProperty(S3OffsetManagerEntry.BUCKET, "someValue"));
-        assertThrows( IllegalArgumentException.class, () -> underTest.setProperty(S3OffsetManagerEntry.OBJECT_KEY, "someValue"));
-        assertThrows( IllegalArgumentException.class, () -> underTest.setProperty(S3OffsetManagerEntry.TOPIC, "someValue"));
-        assertThrows( IllegalArgumentException.class, () -> underTest.setProperty(S3OffsetManagerEntry.PARTITION, "someValue"));
-        assertThrows( IllegalArgumentException.class, () -> underTest.setProperty(S3OffsetManagerEntry.RECORD_COUNT, "someValue"));
+        assertThrows(IllegalArgumentException.class,
+                () -> underTest.setProperty(S3OffsetManagerEntry.BUCKET, "someValue"));
+        assertThrows(IllegalArgumentException.class,
+                () -> underTest.setProperty(S3OffsetManagerEntry.OBJECT_KEY, "someValue"));
+        assertThrows(IllegalArgumentException.class,
+                () -> underTest.setProperty(S3OffsetManagerEntry.TOPIC, "someValue"));
+        assertThrows(IllegalArgumentException.class,
+                () -> underTest.setProperty(S3OffsetManagerEntry.PARTITION, "someValue"));
+        assertThrows(IllegalArgumentException.class,
+                () -> underTest.setProperty(S3OffsetManagerEntry.RECORD_COUNT, "someValue"));
     }
 
     @Test
-    public void testConstructorExpressedInGetters() {
+    void testConstructorExpressedInGetters() {
         assertThat(underTest.getKey()).isEqualTo("s3ObjectKey");
         assertThat(underTest.getTopic()).isEqualTo("topic");
         assertThat(underTest.getPartition()).isEqualTo(1);
@@ -51,7 +72,7 @@ public class S3OffsetManagerEntryTest {
     }
 
     @Test
-    public void testRecordCounterIncrementer() {
+    void testRecordCounterIncrementer() {
         assertThat(underTest.getRecordCount()).isEqualTo(0L);
         assertThat(underTest.shouldSkipRecord(0)).isFalse();
         underTest.incrementRecordCount();

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntryTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntryTest.java
@@ -17,33 +17,45 @@
 package io.aiven.kafka.connect.s3.source.utils;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class S3OffsetManagerEntryTest {
+
+    private static final String  DFLT_BUCKET = "bucket";
+    private static final String  DFLT_KEY = "s3ObjectKey";
+    private static final String  DFLT_TOPIC = "topic";
+    private static final int  DFLT_PARTITION = 1;
 
     private S3OffsetManagerEntry underTest;
     @BeforeEach
     public void setup() {
-        underTest = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "topic", 1);
+        underTest = new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION);
     }
     @Test
     void testConstructorExpressedInMaps() {
 
         Map<String, Object> map = underTest.getProperties();
-        assertThat(map.get(S3OffsetManagerEntry.BUCKET)).isEqualTo("bucket");
-        assertThat(map.get(S3OffsetManagerEntry.OBJECT_KEY)).isEqualTo("s3ObjectKey");
-        assertThat(map.get(S3OffsetManagerEntry.TOPIC)).isEqualTo("topic");
+        assertThat(map.get(S3OffsetManagerEntry.BUCKET)).isEqualTo(DFLT_BUCKET);
+        assertThat(map.get(S3OffsetManagerEntry.OBJECT_KEY)).isEqualTo(DFLT_KEY);
+        assertThat(map.get(S3OffsetManagerEntry.TOPIC)).isEqualTo(DFLT_TOPIC);
         assertThat(map.get(S3OffsetManagerEntry.PARTITION)).isEqualTo(1);
         assertThat(map.get(S3OffsetManagerEntry.RECORD_COUNT)).isEqualTo(0L);
 
         map = underTest.getManagerKey().getPartitionMap();
-        assertThat(map.get(S3OffsetManagerEntry.BUCKET)).isEqualTo("bucket");
-        assertThat(map.get(S3OffsetManagerEntry.TOPIC)).isEqualTo("topic");
+        assertThat(map.get(S3OffsetManagerEntry.BUCKET)).isEqualTo(DFLT_BUCKET);
+        assertThat(map.get(S3OffsetManagerEntry.TOPIC)).isEqualTo(DFLT_TOPIC);
         assertThat(map.get(S3OffsetManagerEntry.PARTITION)).isEqualTo(1);
     }
 
@@ -51,34 +63,82 @@ class S3OffsetManagerEntryTest {
     void testSetProperty() {
         underTest.setProperty("Foo", "bar");
         assertThat(underTest.getProperties().get("Foo")).isEqualTo("bar");
-        assertThrows(IllegalArgumentException.class,
-                () -> underTest.setProperty(S3OffsetManagerEntry.BUCKET, "someValue"));
-        assertThrows(IllegalArgumentException.class,
-                () -> underTest.setProperty(S3OffsetManagerEntry.OBJECT_KEY, "someValue"));
-        assertThrows(IllegalArgumentException.class,
-                () -> underTest.setProperty(S3OffsetManagerEntry.TOPIC, "someValue"));
-        assertThrows(IllegalArgumentException.class,
-                () -> underTest.setProperty(S3OffsetManagerEntry.PARTITION, "someValue"));
-        assertThrows(IllegalArgumentException.class,
-                () -> underTest.setProperty(S3OffsetManagerEntry.RECORD_COUNT, "someValue"));
+        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.BUCKET, "someValue")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.OBJECT_KEY, "someValue")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.TOPIC, "someValue")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.PARTITION, "someValue")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> underTest.setProperty(S3OffsetManagerEntry.RECORD_COUNT, "someValue")).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void testConstructorExpressedInGetters() {
-        assertThat(underTest.getKey()).isEqualTo("s3ObjectKey");
-        assertThat(underTest.getTopic()).isEqualTo("topic");
-        assertThat(underTest.getPartition()).isEqualTo(1);
+        assertThat(underTest.getKey()).isEqualTo(DFLT_KEY);
+        assertThat(underTest.getTopic()).isEqualTo(DFLT_TOPIC);
+        assertThat(underTest.getPartition()).isEqualTo(DFLT_PARTITION);
         assertThat(underTest.getRecordCount()).isEqualTo(0L);
     }
 
-    @Test
-    void testRecordCounterIncrementer() {
-        assertThat(underTest.getRecordCount()).isEqualTo(0L);
-        assertThat(underTest.shouldSkipRecord(0)).isFalse();
-        underTest.incrementRecordCount();
-        assertThat(underTest.getRecordCount()).isEqualTo(1L);
-        assertThat(underTest.shouldSkipRecord(0)).isTrue();
-        assertThat(underTest.shouldSkipRecord(1)).isFalse();
-        assertThat(underTest.shouldSkipRecord(2)).isFalse();
+
+    public void testFromProperties() {
+        assertThat(underTest.fromProperties(underTest.getProperties()).compareTo(underTest)).isEqualTo(0);
+        assertThat(underTest.fromProperties(null)).isNull();
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("fromPropertiesThrowingExceptionData")
+    public void testFromPropertiesThrowingException(String name, Map<String, Object> map, Class<?> expected) {
+        assertThatThrownBy(() -> underTest.fromProperties(map)).as(name+" does not throw exception: "+expected.getName()).isInstanceOf(expected);
+    }
+
+    private static Map<String, Object> createPopulatedMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(S3OffsetManagerEntry.BUCKET, DFLT_BUCKET);
+        map.put(S3OffsetManagerEntry.OBJECT_KEY, DFLT_KEY);
+        map.put(S3OffsetManagerEntry.TOPIC, DFLT_TOPIC);
+        map.put(S3OffsetManagerEntry.PARTITION, DFLT_PARTITION);
+        map.put(S3OffsetManagerEntry.RECORD_COUNT, 0L);
+        return map;
+    }
+    private static Stream<Arguments> fromPropertiesThrowingExceptionData() {
+        String[] fields = {S3OffsetManagerEntry.BUCKET, S3OffsetManagerEntry.OBJECT_KEY, S3OffsetManagerEntry.TOPIC, S3OffsetManagerEntry.PARTITION, S3OffsetManagerEntry.RECORD_COUNT};
+        List<Arguments> lst = new ArrayList<>();
+
+        for (String field : fields) {
+            Map<String, Object> map = createPopulatedMap();
+            map.remove(field);
+            lst.add(Arguments.of("Missing " + field, map, IllegalArgumentException.class));
+        }
+        return lst.stream();
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("compareToData")
+    void testCompareTo(String name, S3OffsetManagerEntry other, int value) {
+        assertThat(other.compareTo(underTest)).as("Failure in "+name).isEqualTo(value);
+    }
+
+    private static Stream<Arguments> compareToData() {
+        List<Arguments> lst = new ArrayList<>();
+
+        lst.add(Arguments.of("Same values", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION), 0));
+        lst.add(Arguments.of("Bucket before", new S3OffsetManagerEntry(DFLT_BUCKET.substring(0, DFLT_BUCKET.length()-1), DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION), -1));
+        lst.add(Arguments.of("Bucket after", new S3OffsetManagerEntry(DFLT_BUCKET+"5", DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION), 1));
+        lst.add(Arguments.of("Key before", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY.substring(0, DFLT_KEY.length()-1), DFLT_TOPIC, DFLT_PARTITION), -1));
+        lst.add(Arguments.of("Key after", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY+"5", DFLT_TOPIC, DFLT_PARTITION), 1));
+        lst.add(Arguments.of("Topic before", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC.substring(0, DFLT_TOPIC.length()-1), DFLT_PARTITION), -1));
+        lst.add(Arguments.of("Topic after", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC+"5", DFLT_PARTITION), 1));
+        lst.add(Arguments.of("Partition before", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION-1), -1));
+        lst.add(Arguments.of("Partition after", new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION+1), 1));
+
+        S3OffsetManagerEntry entry = new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION);
+        Map<String, Object> map = entry.getProperties();
+        map.put(S3OffsetManagerEntry.RECORD_COUNT, -1L);
+        entry = entry.fromProperties(map);
+        lst.add(Arguments.of("Record count before", entry, -1));
+
+         entry = new S3OffsetManagerEntry(DFLT_BUCKET, DFLT_KEY, DFLT_TOPIC, DFLT_PARTITION);
+        entry.incrementRecordCount();
+        lst.add(Arguments.of("Record count after", entry, 1));
+        return lst.stream();
     }
 }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntryTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerEntryTest.java
@@ -1,0 +1,63 @@
+package io.aiven.kafka.connect.s3.source.utils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class S3OffsetManagerEntryTest {
+
+    private S3OffsetManagerEntry underTest;
+    @BeforeEach
+    public void setup() {
+        underTest = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "topic", 1);
+    }
+    @Test
+    public void testConstructorExpressedInMaps() {
+
+        Map<String,Object> map = underTest.getProperties();
+        assertThat(map.get(S3OffsetManagerEntry.BUCKET)).isEqualTo("bucket");
+        assertThat(map.get(S3OffsetManagerEntry.OBJECT_KEY)).isEqualTo("s3ObjectKey");
+        assertThat(map.get(S3OffsetManagerEntry.TOPIC)).isEqualTo("topic");
+        assertThat(map.get(S3OffsetManagerEntry.PARTITION)).isEqualTo(1);
+        assertThat(map.get(S3OffsetManagerEntry.RECORD_COUNT)).isEqualTo(0L);
+
+        map = underTest.getManagerKey().getPartitionMap();
+        assertThat(map.get(S3OffsetManagerEntry.BUCKET)).isEqualTo("bucket");
+        assertThat(map.get(S3OffsetManagerEntry.TOPIC)).isEqualTo("topic");
+        assertThat(map.get(S3OffsetManagerEntry.PARTITION)).isEqualTo(1);
+    }
+
+    @Test
+    public void testSetProperty() {
+        underTest.setProperty("Foo", "bar");
+        assertThat(underTest.getProperties().get("Foo")).isEqualTo("bar");
+        assertThrows( IllegalArgumentException.class, () -> underTest.setProperty(S3OffsetManagerEntry.BUCKET, "someValue"));
+        assertThrows( IllegalArgumentException.class, () -> underTest.setProperty(S3OffsetManagerEntry.OBJECT_KEY, "someValue"));
+        assertThrows( IllegalArgumentException.class, () -> underTest.setProperty(S3OffsetManagerEntry.TOPIC, "someValue"));
+        assertThrows( IllegalArgumentException.class, () -> underTest.setProperty(S3OffsetManagerEntry.PARTITION, "someValue"));
+        assertThrows( IllegalArgumentException.class, () -> underTest.setProperty(S3OffsetManagerEntry.RECORD_COUNT, "someValue"));
+    }
+
+    @Test
+    public void testConstructorExpressedInGetters() {
+        assertThat(underTest.getKey()).isEqualTo("s3ObjectKey");
+        assertThat(underTest.getTopic()).isEqualTo("topic");
+        assertThat(underTest.getPartition()).isEqualTo(1);
+        assertThat(underTest.getRecordCount()).isEqualTo(0L);
+    }
+
+    @Test
+    public void testRecordCounterIncrementer() {
+        assertThat(underTest.getRecordCount()).isEqualTo(0L);
+        assertThat(underTest.shouldSkipRecord(0)).isFalse();
+        underTest.incrementRecordCount();
+        assertThat(underTest.getRecordCount()).isEqualTo(1L);
+        assertThat(underTest.shouldSkipRecord(0)).isTrue();
+        assertThat(underTest.shouldSkipRecord(1)).isFalse();
+        assertThat(underTest.shouldSkipRecord(2)).isFalse();
+    }
+}

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3OffsetManagerTest.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.connect.s3.source.utils;
 
+import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.AWS_S3_BUCKET_NAME_CONFIG;
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.TARGET_TOPICS;
 import static io.aiven.kafka.connect.s3.source.config.S3SourceConfig.TARGET_TOPIC_PARTITIONS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,19 +30,18 @@ import java.util.Map;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 
+import io.aiven.kafka.connect.common.source.offsets.OffsetManager;
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-final class OffsetManagerTest {
+final class S3OffsetManagerTest {
 
     private Map<String, String> properties;
     private static final String TEST_BUCKET = "test-bucket";
-
     private S3SourceConfig s3SourceConfig;
-
     @BeforeEach
     public void setUp() {
         properties = new HashMap<>();
@@ -66,8 +66,7 @@ final class OffsetManagerTest {
         offsets.put(partitionKey, offsetValue);
 
         when(offsetStorageReader.offsets(any())).thenReturn(offsets);
-
-        final OffsetManager offsetManager = new OffsetManager(sourceTaskContext, s3SourceConfig);
+        final OffsetManager offsetManager = new S3OffsetManager(sourceTaskContext, s3SourceConfig);
 
         final Map<Map<String, Object>, Map<String, Object>> retrievedOffsets = offsetManager.getOffsets();
         assertThat(retrievedOffsets.size()).isEqualTo(1);
@@ -81,7 +80,7 @@ final class OffsetManagerTest {
         final Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
         offsets.put(offsetEntry.getManagerKey().getPartitionMap(), offsetEntry.getProperties());
 
-        final OffsetManager underTest = new OffsetManager(offsets);
+        final OffsetManager underTest = new S3OffsetManager(offsets);
 
         offsetEntry.setProperty("MyProperty", "WOW");
 
@@ -98,7 +97,7 @@ final class OffsetManagerTest {
     @Test
     void updateCurrentOffsetsTestNewEntry() {
 
-        final OffsetManager underTest = new OffsetManager(new HashMap<>());
+        final OffsetManager underTest = new S3OffsetManager(new HashMap<>());
 
         final TestingManagerEntry offsetEntry = new TestingManagerEntry("bucket", "topic1", 0);
         underTest.updateCurrentOffsets(offsetEntry);
@@ -115,7 +114,7 @@ final class OffsetManagerTest {
     @Test
     void updateCurrentOffsetsDataNotLost() {
 
-        final OffsetManager underTest = new OffsetManager(new HashMap<>());
+        final OffsetManager underTest = new S3OffsetManager(new HashMap<>());
 
         final TestingManagerEntry offsetEntry = new TestingManagerEntry("bucket", "topic1", 0);
         offsetEntry.setProperty("test", "WOW");
@@ -134,7 +133,7 @@ final class OffsetManagerTest {
     }
 
     private void setBasicProperties() {
-        properties.put(S3SourceConfig.AWS_S3_BUCKET_NAME_CONFIG, TEST_BUCKET);
+        properties.put(AWS_S3_BUCKET_NAME_CONFIG, TEST_BUCKET);
         properties.put(TARGET_TOPIC_PARTITIONS, "0,1");
         properties.put(TARGET_TOPICS, "topic1,topic2");
     }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecordTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecordTest.java
@@ -1,16 +1,20 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.aiven.kafka.connect.s3.source.utils;
-
-import io.aiven.kafka.connect.s3.source.input.Transformer;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
-import org.apache.kafka.connect.source.SourceRecord;
-import org.apache.kafka.connect.storage.Converter;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -18,22 +22,33 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class S3SourceRecordTest {
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.storage.Converter;
+
+import org.junit.jupiter.api.Test;
+
+class S3SourceRecordTest {
 
     @Test
     void testCreateSourceRecord() {
-        Converter valueConverter = mock(Converter.class);
-        Converter keyConverter = mock(Converter.class);
-        S3OffsetManagerEntry offsetManagerEntry = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "test-topic", 1);
-        final S3SourceRecord s3SourceRecord = new S3SourceRecord(offsetManagerEntry, "mock-key".getBytes(StandardCharsets.UTF_8), "mock-value".getBytes(StandardCharsets.UTF_8));
+        final Converter valueConverter = mock(Converter.class);
+        final Converter keyConverter = mock(Converter.class);
+        final S3OffsetManagerEntry offsetManagerEntry = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "test-topic",
+                1);
+        final S3SourceRecord s3SourceRecord = new S3SourceRecord(offsetManagerEntry,
+                "mock-key".getBytes(StandardCharsets.UTF_8), "mock-value".getBytes(StandardCharsets.UTF_8));
 
         when(valueConverter.toConnectData(anyString(), any()))
                 .thenReturn(new SchemaAndValue(Schema.BYTES_SCHEMA, "value-converted"));
 
-        when(keyConverter.toConnectData(anyString(), any()))
-                .thenReturn(new SchemaAndValue(null, "key-converted"));
+        when(keyConverter.toConnectData(anyString(), any())).thenReturn(new SchemaAndValue(null, "key-converted"));
 
-        SourceRecord sourceRecord = s3SourceRecord.getSourceRecord(Optional.of(keyConverter), valueConverter);
+        final SourceRecord sourceRecord = s3SourceRecord.getSourceRecord(Optional.of(keyConverter), valueConverter);
         assertThat(sourceRecord.key()).isEqualTo("key-converted");
         assertThat(sourceRecord.value()).isEqualTo("value-converted");
         assertThat(sourceRecord.sourcePartition()).isEqualTo(offsetManagerEntry.getManagerKey().getPartitionMap());

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecordTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecordTest.java
@@ -1,0 +1,46 @@
+package io.aiven.kafka.connect.s3.source.utils;
+
+import io.aiven.kafka.connect.s3.source.input.Transformer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.storage.Converter;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class S3SourceRecordTest {
+
+    @Test
+    void testCreateSourceRecord() {
+        Converter valueConverter = mock(Converter.class);
+        Converter keyConverter = mock(Converter.class);
+        S3OffsetManagerEntry offsetManagerEntry = new S3OffsetManagerEntry("bucket", "s3ObjectKey", "test-topic", 1);
+        final S3SourceRecord s3SourceRecord = new S3SourceRecord(offsetManagerEntry, "mock-key".getBytes(StandardCharsets.UTF_8), "mock-value".getBytes(StandardCharsets.UTF_8));
+
+        when(valueConverter.toConnectData(anyString(), any()))
+                .thenReturn(new SchemaAndValue(Schema.BYTES_SCHEMA, "value-converted"));
+
+        when(keyConverter.toConnectData(anyString(), any()))
+                .thenReturn(new SchemaAndValue(null, "key-converted"));
+
+        SourceRecord sourceRecord = s3SourceRecord.getSourceRecord(Optional.of(keyConverter), valueConverter);
+        assertThat(sourceRecord.key()).isEqualTo("key-converted");
+        assertThat(sourceRecord.value()).isEqualTo("value-converted");
+        assertThat(sourceRecord.sourcePartition()).isEqualTo(offsetManagerEntry.getManagerKey().getPartitionMap());
+        assertThat(sourceRecord.kafkaPartition()).isEqualTo(offsetManagerEntry.getPartition());
+        assertThat(sourceRecord.sourceOffset()).isEqualTo(offsetManagerEntry.getProperties());
+        assertThat(sourceRecord.valueSchema()).isEqualTo(Schema.BYTES_SCHEMA);
+        assertThat(sourceRecord.keySchema()).isNull();
+        assertThat(sourceRecord.topic()).isEqualTo(offsetManagerEntry.getTopic());
+    }
+}

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIteratorTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIteratorTest.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import io.aiven.kafka.connect.common.source.offsets.OffsetManager;
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 
 import com.amazonaws.services.s3.AmazonS3;
@@ -106,7 +107,7 @@ final class SourceRecordIteratorTest {
         final String[] keys = { "topic-00001-key1.txt", "topic-00001-key2.txt", "topic-00001-key3.txt" };
         multiKeySetUp(keys, DFLT_TOPIC, 1);
         // create an empty offset manager.
-        final OffsetManager offsetManager = new OffsetManager(new HashMap<>());
+        final OffsetManager offsetManager = new S3OffsetManager(new HashMap<>());
 
         final Iterator<S3ObjectSummary> s3ObjectSummaryIterator = s3ObjectSummaries.iterator();
 
@@ -127,7 +128,7 @@ final class SourceRecordIteratorTest {
     void skipObjectsTest() {
         final String[] keys = { "topic-00001-key1.txt", "topic-00001-key2.txt", "topic-00001-key3.txt" };
         final List<S3OffsetManagerEntry> entries = multiKeySetUp(keys, DFLT_TOPIC, 1);
-        final OffsetManager offsetManager = new OffsetManager(new HashMap<>());
+        final OffsetManager offsetManager = new S3OffsetManager(new HashMap<>());
         // set the key to skip.
         offsetManager.updateCurrentOffsets(entries.get(0));
 

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIteratorTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIteratorTest.java
@@ -17,8 +17,6 @@
 package io.aiven.kafka.connect.s3.source.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -26,19 +24,15 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
-import io.aiven.kafka.connect.s3.source.input.Transformer;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,30 +44,25 @@ final class SourceRecordIteratorTest {
 
     private AmazonS3 mockS3Client;
     private S3SourceConfig mockConfig;
-    private Transformer mockTransformer;
-
-    private FileReader mockFileReader;
-
-    private OffsetManager mockOffsetManager;
 
     private List<S3ObjectSummary> s3ObjectSummaries;
 
     private Map<String, S3Object> s3ObjectMap;
 
-    private String getObjectContents(String bucket, String key) {
+    private String getObjectContents(final String bucket, final String key) {
         return String.format("Hello from %s on %s", key, bucket);
     }
 
-    private void createS3Object(S3ObjectSummary summary) {
-        S3Object result = new S3Object();
+    private void createS3Object(final S3ObjectSummary summary) {
+        final S3Object result = new S3Object(); // NOPMD
         result.setKey(summary.getKey());
         result.setBucketName(summary.getBucketName());
         result.setObjectContent(new ByteArrayInputStream(
                 getObjectContents(summary.getBucketName(), summary.getKey()).getBytes(StandardCharsets.UTF_8)));
         s3ObjectMap.put(summary.getKey(), result);
     }
-    private S3ObjectSummary createS3ObjectSummary(String key) {
-        S3ObjectSummary result = new S3ObjectSummary();
+    private S3ObjectSummary createS3ObjectSummary(final String key) {
+        final S3ObjectSummary result = new S3ObjectSummary();
         result.setKey(key);
         result.setBucketName(DFLT_BUCKET);
         createS3Object(result);
@@ -88,25 +77,24 @@ final class SourceRecordIteratorTest {
         when(mockS3Client.getObject(anyString(), anyString()))
                 .thenAnswer(invocation -> s3ObjectMap.get(invocation.getArguments()[1]));
         mockConfig = mock(S3SourceConfig.class);
-        mockTransformer = mock(Transformer.class);
-        mockOffsetManager = mock(OffsetManager.class);
     }
 
-    void assertS3RecordMatches(S3SourceRecord s3SourceRecord, String key, String value, int counter) {
+    void assertS3RecordMatches(final S3SourceRecord s3SourceRecord, final String key, final String value,
+            final int counter) {
         assertThat(s3SourceRecord.getRecordKey())
                 .as(() -> String.format("Wrong record key at %s: %s != %s (expected)", counter,
-                        new String(s3SourceRecord.getRecordKey()), key))
+                        new String(s3SourceRecord.getRecordKey(), StandardCharsets.UTF_8), key))
                 .isEqualTo(key.getBytes(StandardCharsets.UTF_8));
         assertThat(s3SourceRecord.getRecordValue())
                 .as(() -> String.format("Wrong record value at %s: %s != %s (expected)", counter,
-                        new String(s3SourceRecord.getRecordValue()), value))
+                        new String(s3SourceRecord.getRecordValue(), StandardCharsets.UTF_8), value))
                 .isEqualTo(value.getBytes(StandardCharsets.UTF_8));
     }
 
-    private List<S3OffsetManagerEntry> multiKeySetUp(String[] keys, String topic, int partition) {
-        List<S3OffsetManagerEntry> entries = new ArrayList<>();
-        for (String key : keys) {
-            S3ObjectSummary summary = createS3ObjectSummary(key);
+    private List<S3OffsetManagerEntry> multiKeySetUp(final String[] keys, final String topic, final int partition) {
+        final List<S3OffsetManagerEntry> entries = new ArrayList<>();
+        for (final String key : keys) {
+            final S3ObjectSummary summary = createS3ObjectSummary(key);
             entries.add(new S3OffsetManagerEntry(summary.getBucketName(), summary.getKey(), topic, partition));
             s3ObjectSummaries.add(summary);
         }
@@ -114,73 +102,44 @@ final class SourceRecordIteratorTest {
     }
 
     @Test
-    void allObjectsTest() throws Exception {
-        String[] keys = { "topic-00001-key1.txt", "topic-00001-key2.txt", "topic-00001-key3.txt" };
+    void allObjectsTest() {
+        final String[] keys = { "topic-00001-key1.txt", "topic-00001-key2.txt", "topic-00001-key3.txt" };
         multiKeySetUp(keys, DFLT_TOPIC, 1);
         // create an empty offset manager.
-        OffsetManager offsetManager = new OffsetManager(new HashMap<>());
+        final OffsetManager offsetManager = new OffsetManager(new HashMap<>());
 
-        Iterator<S3ObjectSummary> s3ObjectSummaryIterator = s3ObjectSummaries.iterator();
+        final Iterator<S3ObjectSummary> s3ObjectSummaryIterator = s3ObjectSummaries.iterator();
 
-        SourceRecordIterator sourceRecordIterator = new SourceRecordIterator(mockConfig, mockS3Client, offsetManager,
-                new TestingTransformer(), s3ObjectSummaryIterator);
+        final SourceRecordIterator sourceRecordIterator = new SourceRecordIterator(mockConfig, mockS3Client,
+                offsetManager, new TestingTransformer(), s3ObjectSummaryIterator);
         for (int i = 0; i < keys.length; i++) {
-            String key = keys[i];
+            final String key = keys[i];
 
-            // Mock S3Object and InputStream
-            try (S3Object mockS3Object = mock(S3Object.class);
-                    S3ObjectInputStream mockInputStream = new S3ObjectInputStream(
-                            new ByteArrayInputStream(new byte[] {}), null);) {
-                when(mockS3Client.getObject(anyString(), anyString())).thenReturn(mockS3Object);
-                when(mockS3Object.getObjectContent()).thenReturn(mockInputStream);
-
-                when(mockTransformer.getRecords(any(), anyString(), anyInt(), any()))
-                        .thenReturn(Stream.of(new Object()));
-
-                final String outStr = "this is a test";
-                when(mockTransformer.getValueBytes(any(), anyString(), any()))
-                        .thenReturn(outStr.getBytes(StandardCharsets.UTF_8));
-
-                when(mockOffsetManager.getOffsets()).thenReturn(Collections.emptyMap());
-
-                when(mockFileReader.fetchObjectSummaries(any())).thenReturn(Collections.emptyIterator());
-                SourceRecordIterator iterator = new SourceRecordIterator(mockConfig, mockS3Client, mockOffsetManager,
-                        mockTransformer, s3ObjectSummaryIterator);
-
-                assertThat(iterator.hasNext()).isFalse();
-                assertThat(iterator.next()).isNull();
-
-                // when(mockFileReader.fetchObjectSummaries(any())).thenReturn(mockObjectSummaries.listIterator());
-
-                iterator = new SourceRecordIterator(mockConfig, mockS3Client, mockOffsetManager, mockTransformer,
-                        s3ObjectSummaryIterator);
-
-                assertThat(iterator.hasNext()).isTrue();
-                assertThat(iterator.next()).isNotNull();
-
-            }
-            assertThat(sourceRecordIterator.hasNext()).isFalse();
+            assertThat(sourceRecordIterator).hasNext();
+            final S3SourceRecord sourceRecord = sourceRecordIterator.next();
+            assertS3RecordMatches(sourceRecord, key, TestingTransformer.transform(getObjectContents(DFLT_BUCKET, key)),
+                    i);
         }
+        assertThat(sourceRecordIterator.hasNext()).isFalse();
     }
 
     @Test
-    void skipObjectsTest() throws Exception {
-        String[] keys = { "topic-00001-key1.txt", "topic-00001-key2.txt", "topic-00001-key3.txt" };
-        List<S3OffsetManagerEntry> entries = multiKeySetUp(keys, DFLT_TOPIC, 1);
-        OffsetManager offsetManager = new OffsetManager(new HashMap<>());
-        offsetManager.getOffsetValueMap("topic-00001-key1.txt",0);
+    void skipObjectsTest() {
+        final String[] keys = { "topic-00001-key1.txt", "topic-00001-key2.txt", "topic-00001-key3.txt" };
+        final List<S3OffsetManagerEntry> entries = multiKeySetUp(keys, DFLT_TOPIC, 1);
+        final OffsetManager offsetManager = new OffsetManager(new HashMap<>());
         // set the key to skip.
-//        offsetManager.updateCurrentOffsets(entries.get(0));
+        offsetManager.updateCurrentOffsets(entries.get(0));
 
-        Iterator<S3ObjectSummary> s3ObjectSummaryIterator = s3ObjectSummaries.iterator();
+        final Iterator<S3ObjectSummary> s3ObjectSummaryIterator = s3ObjectSummaries.iterator();
 
-        SourceRecordIterator sourceRecordIterator = new SourceRecordIterator(mockConfig, mockS3Client, offsetManager,
-                new TestingTransformer(), s3ObjectSummaryIterator);
+        final SourceRecordIterator sourceRecordIterator = new SourceRecordIterator(mockConfig, mockS3Client,
+                offsetManager, new TestingTransformer(), s3ObjectSummaryIterator);
         for (int i = 1; i < keys.length; i++) {
-            String key = keys[i];
+            final String key = keys[i];
 
             assertThat(sourceRecordIterator).as("at position " + i).hasNext();
-            S3SourceRecord sourceRecord = sourceRecordIterator.next();
+            final S3SourceRecord sourceRecord = sourceRecordIterator.next();
             assertS3RecordMatches(sourceRecord, key, TestingTransformer.transform(getObjectContents(DFLT_BUCKET, key)),
                     i);
         }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIteratorTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIteratorTest.java
@@ -25,15 +25,18 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
@@ -42,68 +45,146 @@ import org.junit.jupiter.api.Test;
 
 final class SourceRecordIteratorTest {
 
+    private static final String DFLT_BUCKET = "bucket";
+    private static final String DFLT_TOPIC = "topic";
+
     private AmazonS3 mockS3Client;
     private S3SourceConfig mockConfig;
-    private OffsetManager mockOffsetManager;
     private Transformer mockTransformer;
 
     private FileReader mockFileReader;
 
+    private OffsetManager mockOffsetManager;
+
+    private List<S3ObjectSummary> s3ObjectSummaries;
+
+    private Map<String, S3Object> s3ObjectMap;
+
+    private String getObjectContents(String bucket, String key) {
+        return String.format("Hello from %s on %s", key, bucket);
+    }
+
+    private void createS3Object(S3ObjectSummary summary) {
+        S3Object result = new S3Object();
+        result.setKey(summary.getKey());
+        result.setBucketName(summary.getBucketName());
+        result.setObjectContent(new ByteArrayInputStream(
+                getObjectContents(summary.getBucketName(), summary.getKey()).getBytes(StandardCharsets.UTF_8)));
+        s3ObjectMap.put(summary.getKey(), result);
+    }
+    private S3ObjectSummary createS3ObjectSummary(String key) {
+        S3ObjectSummary result = new S3ObjectSummary();
+        result.setKey(key);
+        result.setBucketName(DFLT_BUCKET);
+        createS3Object(result);
+        return result;
+    }
+
     @BeforeEach
     public void setUp() {
+        s3ObjectSummaries = new ArrayList<>();
+        s3ObjectMap = new HashMap<>();
         mockS3Client = mock(AmazonS3.class);
+        when(mockS3Client.getObject(anyString(), anyString()))
+                .thenAnswer(invocation -> s3ObjectMap.get(invocation.getArguments()[1]));
         mockConfig = mock(S3SourceConfig.class);
-        mockOffsetManager = mock(OffsetManager.class);
         mockTransformer = mock(Transformer.class);
-        mockFileReader = mock(FileReader.class);
+        mockOffsetManager = mock(OffsetManager.class);
+    }
+
+    void assertS3RecordMatches(S3SourceRecord s3SourceRecord, String key, String value, int counter) {
+        assertThat(s3SourceRecord.getRecordKey())
+                .as(() -> String.format("Wrong record key at %s: %s != %s (expected)", counter,
+                        new String(s3SourceRecord.getRecordKey()), key))
+                .isEqualTo(key.getBytes(StandardCharsets.UTF_8));
+        assertThat(s3SourceRecord.getRecordValue())
+                .as(() -> String.format("Wrong record value at %s: %s != %s (expected)", counter,
+                        new String(s3SourceRecord.getRecordValue()), value))
+                .isEqualTo(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private List<S3OffsetManagerEntry> multiKeySetUp(String[] keys, String topic, int partition) {
+        List<S3OffsetManagerEntry> entries = new ArrayList<>();
+        for (String key : keys) {
+            S3ObjectSummary summary = createS3ObjectSummary(key);
+            entries.add(new S3OffsetManagerEntry(summary.getBucketName(), summary.getKey(), topic, partition));
+            s3ObjectSummaries.add(summary);
+        }
+        return entries;
     }
 
     @Test
-    void testIteratorProcessesS3Objects() throws Exception {
-        final S3ObjectSummary mockSummary = new S3ObjectSummary();
-        mockSummary.setKey("topic-00001-abc123.txt");
+    void allObjectsTest() throws Exception {
+        String[] keys = { "topic-00001-key1.txt", "topic-00001-key2.txt", "topic-00001-key3.txt" };
+        multiKeySetUp(keys, DFLT_TOPIC, 1);
+        // create an empty offset manager.
+        OffsetManager offsetManager = new OffsetManager(new HashMap<>());
 
-        // Mock list of S3 object summaries
-        final List<S3ObjectSummary> mockObjectSummaries = Collections.singletonList(mockSummary);
+        Iterator<S3ObjectSummary> s3ObjectSummaryIterator = s3ObjectSummaries.iterator();
 
-        final ListObjectsV2Result result = mockListObjectsResult(mockObjectSummaries);
-        when(mockS3Client.listObjectsV2(anyString())).thenReturn(result);
+        SourceRecordIterator sourceRecordIterator = new SourceRecordIterator(mockConfig, mockS3Client, offsetManager,
+                new TestingTransformer(), s3ObjectSummaryIterator);
+        for (int i = 0; i < keys.length; i++) {
+            String key = keys[i];
 
-        // Mock S3Object and InputStream
-        try (S3Object mockS3Object = mock(S3Object.class);
-                S3ObjectInputStream mockInputStream = new S3ObjectInputStream(new ByteArrayInputStream(new byte[] {}),
-                        null);) {
-            when(mockS3Client.getObject(anyString(), anyString())).thenReturn(mockS3Object);
-            when(mockS3Object.getObjectContent()).thenReturn(mockInputStream);
+            // Mock S3Object and InputStream
+            try (S3Object mockS3Object = mock(S3Object.class);
+                    S3ObjectInputStream mockInputStream = new S3ObjectInputStream(
+                            new ByteArrayInputStream(new byte[] {}), null);) {
+                when(mockS3Client.getObject(anyString(), anyString())).thenReturn(mockS3Object);
+                when(mockS3Object.getObjectContent()).thenReturn(mockInputStream);
 
-            when(mockTransformer.getRecords(any(), anyString(), anyInt(), any())).thenReturn(Stream.of(new Object()));
+                when(mockTransformer.getRecords(any(), anyString(), anyInt(), any()))
+                        .thenReturn(Stream.of(new Object()));
 
-            final String outStr = "this is a test";
-            when(mockTransformer.getValueBytes(any(), anyString(), any()))
-                    .thenReturn(outStr.getBytes(StandardCharsets.UTF_8));
+                final String outStr = "this is a test";
+                when(mockTransformer.getValueBytes(any(), anyString(), any()))
+                        .thenReturn(outStr.getBytes(StandardCharsets.UTF_8));
 
-            when(mockOffsetManager.getOffsets()).thenReturn(Collections.emptyMap());
+                when(mockOffsetManager.getOffsets()).thenReturn(Collections.emptyMap());
 
-            when(mockFileReader.fetchObjectSummaries(any())).thenReturn(Collections.emptyIterator());
-            SourceRecordIterator iterator = new SourceRecordIterator(mockConfig, mockS3Client, "test-bucket",
-                    mockOffsetManager, mockTransformer, mockFileReader);
+                when(mockFileReader.fetchObjectSummaries(any())).thenReturn(Collections.emptyIterator());
+                SourceRecordIterator iterator = new SourceRecordIterator(mockConfig, mockS3Client, mockOffsetManager,
+                        mockTransformer, s3ObjectSummaryIterator);
 
-            assertThat(iterator.hasNext()).isFalse();
-            assertThat(iterator.next()).isNull();
+                assertThat(iterator.hasNext()).isFalse();
+                assertThat(iterator.next()).isNull();
 
-            when(mockFileReader.fetchObjectSummaries(any())).thenReturn(mockObjectSummaries.listIterator());
+                // when(mockFileReader.fetchObjectSummaries(any())).thenReturn(mockObjectSummaries.listIterator());
 
-            iterator = new SourceRecordIterator(mockConfig, mockS3Client, "test-bucket", mockOffsetManager,
-                    mockTransformer, mockFileReader);
+                iterator = new SourceRecordIterator(mockConfig, mockS3Client, mockOffsetManager, mockTransformer,
+                        s3ObjectSummaryIterator);
 
-            assertThat(iterator.hasNext()).isTrue();
-            assertThat(iterator.next()).isNotNull();
+                assertThat(iterator.hasNext()).isTrue();
+                assertThat(iterator.next()).isNotNull();
+
+            }
+            assertThat(sourceRecordIterator.hasNext()).isFalse();
         }
     }
 
-    private ListObjectsV2Result mockListObjectsResult(final List<S3ObjectSummary> summaries) {
-        final ListObjectsV2Result result = mock(ListObjectsV2Result.class);
-        when(result.getObjectSummaries()).thenReturn(summaries);
-        return result;
+    @Test
+    void skipObjectsTest() throws Exception {
+        String[] keys = { "topic-00001-key1.txt", "topic-00001-key2.txt", "topic-00001-key3.txt" };
+        List<S3OffsetManagerEntry> entries = multiKeySetUp(keys, DFLT_TOPIC, 1);
+        OffsetManager offsetManager = new OffsetManager(new HashMap<>());
+        offsetManager.getOffsetValueMap("topic-00001-key1.txt",0);
+        // set the key to skip.
+//        offsetManager.updateCurrentOffsets(entries.get(0));
+
+        Iterator<S3ObjectSummary> s3ObjectSummaryIterator = s3ObjectSummaries.iterator();
+
+        SourceRecordIterator sourceRecordIterator = new SourceRecordIterator(mockConfig, mockS3Client, offsetManager,
+                new TestingTransformer(), s3ObjectSummaryIterator);
+        for (int i = 1; i < keys.length; i++) {
+            String key = keys[i];
+
+            assertThat(sourceRecordIterator).as("at position " + i).hasNext();
+            S3SourceRecord sourceRecord = sourceRecordIterator.next();
+            assertS3RecordMatches(sourceRecord, key, TestingTransformer.transform(getObjectContents(DFLT_BUCKET, key)),
+                    i);
+        }
+
+        assertThat(sourceRecordIterator.hasNext()).isFalse();
     }
 }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/TestingTransformer.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/TestingTransformer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.source.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+import io.aiven.kafka.connect.s3.source.input.Transformer;
+
+import com.nimbusds.jose.util.IOUtils;
+import org.apache.commons.io.function.IOSupplier;
+
+public class TestingTransformer implements Transformer {
+
+    public static String transform(String original) {
+        return String.format("Transformed(%s)", original);
+    }
+    @Override
+    public void configureValueConverter(Map<String, String> config, S3SourceConfig s3SourceConfig) {
+        config.put("TestingTransformer", "True");
+    }
+
+    @Override
+    public Stream<Object> getRecords(IOSupplier<InputStream> inputStream, String topic, int topicPartition,
+            S3SourceConfig s3SourceConfig) {
+        try {
+            return Stream.of(transform(IOUtils.readInputStreamToString(inputStream.get())));
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading input stream", e);
+        }
+    }
+
+    @Override
+    public byte[] getValueBytes(Object record, String topic, S3SourceConfig s3SourceConfig) {
+        return ((String) record).getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/TestingTransformer.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/TestingTransformer.java
@@ -22,9 +22,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.errors.ConnectException;
 
-import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 
 import com.nimbusds.jose.util.IOUtils;
@@ -37,13 +37,13 @@ public class TestingTransformer implements Transformer { // NOPMD this is not a 
         return String.format("Transformed(%s)", original);
     }
     @Override
-    public void configureValueConverter(final Map<String, String> config, final S3SourceConfig s3SourceConfig) {
+    public void configureValueConverter(final Map<String, String> config, final AbstractConfig s3SourceConfig) {
         config.put("TestingTransformer", "True");
     }
 
     @Override
     public Stream<Object> getRecords(final IOSupplier<InputStream> inputStream, final String topic,
-            final int topicPartition, final S3SourceConfig s3SourceConfig) {
+            final int topicPartition, final AbstractConfig s3SourceConfig) {
         try {
             return Stream.of(transform(IOUtils.readInputStreamToString(inputStream.get())));
         } catch (IOException e) {
@@ -52,7 +52,7 @@ public class TestingTransformer implements Transformer { // NOPMD this is not a 
     }
 
     @Override
-    public byte[] getValueBytes(final Object record, final String topic, final S3SourceConfig s3SourceConfig) {
+    public byte[] getValueBytes(final Object record, final String topic, final AbstractConfig s3SourceConfig) {
         return ((String) record).getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/TestingTransformer.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/TestingTransformer.java
@@ -22,34 +22,37 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.apache.kafka.connect.errors.ConnectException;
+
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 import io.aiven.kafka.connect.s3.source.input.Transformer;
 
 import com.nimbusds.jose.util.IOUtils;
 import org.apache.commons.io.function.IOSupplier;
 
-public class TestingTransformer implements Transformer {
+public class TestingTransformer implements Transformer { // NOPMD this is not a test class it is a class used by other
+                                                         // test classes
 
-    public static String transform(String original) {
+    public static String transform(final String original) {
         return String.format("Transformed(%s)", original);
     }
     @Override
-    public void configureValueConverter(Map<String, String> config, S3SourceConfig s3SourceConfig) {
+    public void configureValueConverter(final Map<String, String> config, final S3SourceConfig s3SourceConfig) {
         config.put("TestingTransformer", "True");
     }
 
     @Override
-    public Stream<Object> getRecords(IOSupplier<InputStream> inputStream, String topic, int topicPartition,
-            S3SourceConfig s3SourceConfig) {
+    public Stream<Object> getRecords(final IOSupplier<InputStream> inputStream, final String topic,
+            final int topicPartition, final S3SourceConfig s3SourceConfig) {
         try {
             return Stream.of(transform(IOUtils.readInputStreamToString(inputStream.get())));
         } catch (IOException e) {
-            throw new RuntimeException("Error reading input stream", e);
+            throw new ConnectException("Error reading input stream", e);
         }
     }
 
     @Override
-    public byte[] getValueBytes(Object record, String topic, S3SourceConfig s3SourceConfig) {
+    public byte[] getValueBytes(final Object record, final String topic, final S3SourceConfig s3SourceConfig) {
         return ((String) record).getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ val avroConverterVersion by extra("7.2.2")
 val avroDataVersion by extra("7.2.2")
 val awaitilityVersion by extra("4.2.1")
 val commonsTextVersion by extra("1.11.0")
+val commonsCollections4Version by extra("4.4")
 val hadoopVersion by extra("3.4.0")
 val hamcrestVersion by extra("2.2")
 val jacksonVersion by extra("2.15.3")
@@ -30,6 +31,9 @@ dependencyResolutionManagement {
     create("apache") {
       library("avro", "org.apache.avro:avro:$avroVersion")
       library("commons-text", "org.apache.commons:commons-text:$commonsTextVersion")
+      library(
+          "commons-collection4",
+          "org.apache.commons:commons-collections4:$commonsCollections4Version")
       library("kafka-connect-api", "org.apache.kafka:connect-api:$kafkaVersion")
       library("kafka-connect-json", "org.apache.kafka:connect-json:$kafkaVersion")
       library("kafka-connect-runtime", "org.apache.kafka:connect-runtime:$kafkaVersion")


### PR DESCRIPTION
* Refactor Source Record Iterator
* Decouples OffsetManagement & Iterator
* Reduce the time memory footprint and memory overhead of creating the input. By creating a streaming system that only constructs items as they are needed. Reducing the dependency on Lists and other in-memory collections.