### PR TITLE
Read large avro files [KCON-64]

### DIFF
--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationBase.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationBase.java
@@ -159,7 +159,7 @@ public interface IntegrationBase {
             consumer.subscribe(Collections.singletonList(topic));
 
             final List<V> recordValues = new ArrayList<>();
-            await().atMost(Duration.ofMinutes(2)).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
+            await().atMost(Duration.ofMinutes(10)).pollInterval(Duration.ofSeconds(5)).untilAsserted(() -> {
                 final ConsumerRecords<K, V> records = consumer.poll(Duration.ofMillis(500L));
                 for (final ConsumerRecord<K, V> record : records) {
                     recordValues.add(record.value());

--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationBase.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationBase.java
@@ -159,7 +159,7 @@ public interface IntegrationBase {
             consumer.subscribe(Collections.singletonList(topic));
 
             final List<V> recordValues = new ArrayList<>();
-            await().atMost(Duration.ofMinutes(10)).pollInterval(Duration.ofSeconds(5)).untilAsserted(() -> {
+            await().atMost(Duration.ofMinutes(5)).pollInterval(Duration.ofSeconds(5)).untilAsserted(() -> {
                 final ConsumerRecords<K, V> records = consumer.poll(Duration.ofMillis(500L));
                 for (final ConsumerRecord<K, V> record : records) {
                     recordValues.add(record.value());

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/AvroTransformer.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/input/AvroTransformer.java
@@ -78,7 +78,7 @@ public class AvroTransformer implements Transformer {
             // Wrap DataFileStream in a Stream using a custom Spliterator for lazy processing
             return StreamSupport.stream(new AvroRecordSpliterator<>(dataFileStream), false).onClose(() -> {
                 try {
-                    inputStream.close(); // Ensure the reader is closed after streaming
+                    dataFileStream.close(); // Ensure the reader is closed after streaming
                 } catch (IOException e) {
                     LOGGER.error("Error closing BufferedReader: {}", e.getMessage(), e);
                 }


### PR DESCRIPTION

Current implementation cannot handle large Avro files, due to the initialisation of stream in try resources within transformer.

- In this custom splitter - The tryAdvance method reads one record at a time and processes it. 
- Updated integration test with large number of avro records in one object

