### PR TITLE
Update to add errors.tolerance configuration

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigDef;
 
+import io.aiven.kafka.connect.common.config.enums.ErrorsTolerance;
 import io.aiven.kafka.connect.common.source.input.InputFormat;
 
 public class SourceCommonConfig extends CommonConfig {
@@ -60,6 +61,10 @@ public class SourceCommonConfig extends CommonConfig {
     }
     public String getTargetTopicPartitions() {
         return sourceConfigFragment.getTargetTopicPartitions();
+    }
+
+    public ErrorsTolerance getErrorsTolerance() {
+        return ErrorsTolerance.forName(sourceConfigFragment.getErrorsTolerance());
     }
 
     public int getMaxPollRecords() {

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceConfigFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceConfigFragment.java
@@ -49,8 +49,8 @@ public final class SourceConfigFragment extends ConfigFragment {
                 ConfigDef.Importance.MEDIUM, "Max poll records", GROUP_OTHER, sourcePollingConfigCounter++,
                 ConfigDef.Width.NONE, MAX_POLL_RECORDS);
         // KIP-298 Error Handling in Connect
-        configDef.define(ERRORS_TOLERANCE, ConfigDef.Type.STRING, "none", new ErrorsToleranceValidator(),
-                ConfigDef.Importance.MEDIUM,
+        configDef.define(ERRORS_TOLERANCE, ConfigDef.Type.STRING, ErrorsTolerance.NONE.name(),
+                new ErrorsToleranceValidator(), ConfigDef.Importance.MEDIUM,
                 "Indicates to the connector what level of exceptions are allowed before the connector stops, supported values : none,all",
                 GROUP_OTHER, sourcePollingConfigCounter++, ConfigDef.Width.NONE, ERRORS_TOLERANCE);
 
@@ -96,7 +96,7 @@ public final class SourceConfigFragment extends ConfigFragment {
         @Override
         public void ensureValid(final String name, final Object value) {
             final String errorsTolerance = (String) value;
-            if (StringUtils.isBlank(errorsTolerance)) {
+            if (StringUtils.isNotBlank(errorsTolerance)) {
                 // This will throw an Exception if not a valid value.
                 ErrorsTolerance.forName(errorsTolerance);
             }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/enums/ErrorsTolerance.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/enums/ErrorsTolerance.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.config.enums;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.apache.kafka.common.config.ConfigException;
+
+public enum ErrorsTolerance {
+
+    NONE("none"), ALL("all");
+
+    public final String name;
+
+    ErrorsTolerance(final String name) {
+        this.name = name;
+    }
+
+    public static ErrorsTolerance forName(final String name) {
+        Objects.requireNonNull(name, "name cannot be null");
+        for (final ErrorsTolerance errorsTolerance : ErrorsTolerance.values()) {
+            if (errorsTolerance.name.equalsIgnoreCase(name)) {
+                return errorsTolerance;
+            }
+        }
+        throw new ConfigException(String.format("Unknown errors.tolerance type: %s, allowed values %s ", name,
+                Arrays.toString(ErrorsTolerance.values())));
+    }
+}

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/enums/ErrorsTolerance.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/enums/ErrorsTolerance.java
@@ -25,7 +25,7 @@ public enum ErrorsTolerance {
 
     NONE("none"), ALL("all");
 
-    public final String name;
+    private final String name;
 
     ErrorsTolerance(final String name) {
         this.name = name;


### PR DESCRIPTION
Add Errors tolerance configuration.

1) Allows configuration of the connect framework feature and how it should handle source records which are malformed or unable to be added to a kafka topic.
2) Also checks RecordProcessor and if a failed or malformed record should be ignored or cause the failure of the Connector.