### PR TITLE
Configure s3 api to use AWS Prefix

### DIFF
--- a/s3-commons/src/main/java/io/aiven/kafka/connect/config/s3/S3ConfigFragment.java
+++ b/s3-commons/src/main/java/io/aiven/kafka/connect/config/s3/S3ConfigFragment.java
@@ -99,6 +99,7 @@ public final class S3ConfigFragment extends ConfigFragment {
     public static final String AWS_S3_REGION_CONFIG = "aws.s3.region";
     public static final String AWS_S3_PART_SIZE = "aws.s3.part.size.bytes";
 
+    public static final String AWS_S3_START_AFTER_CONFIG = "aws.s3.startAfter";
     public static final String AWS_S3_PREFIX_CONFIG = "aws.s3.prefix";
     public static final String AWS_STS_ROLE_ARN = "aws.sts.role.arn";
     public static final String AWS_STS_ROLE_EXTERNAL_ID = "aws.sts.role.external.id";
@@ -216,6 +217,15 @@ public final class S3ConfigFragment extends ConfigFragment {
                 ConfigDef.Importance.MEDIUM, "AWS S3 Region, e.g. us-east-1", GROUP_AWS, awsGroupCounter++,
                 ConfigDef.Width.NONE, AWS_S3_REGION_CONFIG);
 
+        configDef.define(AWS_S3_PREFIX_CONFIG, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
+                ConfigDef.Importance.MEDIUM, "Prefix for stored objects, e.g. cluster-1/", GROUP_AWS, awsGroupCounter++,
+                ConfigDef.Width.NONE, AWS_S3_PREFIX_CONFIG);
+
+        configDef.define(AWS_S3_START_AFTER_CONFIG, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
+                ConfigDef.Importance.MEDIUM,
+                "If you want to start reading events from a specific location you can start reading them after a certain file name in S3 by configuring this.",
+                GROUP_AWS, awsGroupCounter++, ConfigDef.Width.NONE, AWS_S3_START_AFTER_CONFIG);
+
         configDef.define(FETCH_PAGE_SIZE, ConfigDef.Type.INT, 10, ConfigDef.Range.atLeast(1),
                 ConfigDef.Importance.MEDIUM, "AWS S3 Fetch page size", GROUP_AWS, awsGroupCounter++, // NOPMD
                 // UnusedAssignment
@@ -252,10 +262,6 @@ public final class S3ConfigFragment extends ConfigFragment {
     }
 
     static void addDeprecatedConfiguration(final ConfigDef configDef) {
-        configDef.define(AWS_S3_PREFIX_CONFIG, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
-                ConfigDef.Importance.MEDIUM,
-                "[Deprecated] Use `file.name.template` instead. Prefix for stored objects, e.g. cluster-1/", GROUP_AWS,
-                0, ConfigDef.Width.NONE, AWS_S3_PREFIX_CONFIG);
 
         configDef.define(AWS_ACCESS_KEY_ID, ConfigDef.Type.PASSWORD, null, new NonEmptyPassword() {
             @Override

--- a/s3-commons/src/main/java/io/aiven/kafka/connect/config/s3/S3ConfigFragment.java
+++ b/s3-commons/src/main/java/io/aiven/kafka/connect/config/s3/S3ConfigFragment.java
@@ -99,7 +99,6 @@ public final class S3ConfigFragment extends ConfigFragment {
     public static final String AWS_S3_REGION_CONFIG = "aws.s3.region";
     public static final String AWS_S3_PART_SIZE = "aws.s3.part.size.bytes";
 
-    public static final String AWS_S3_START_AFTER_CONFIG = "aws.s3.startAfter";
     public static final String AWS_S3_PREFIX_CONFIG = "aws.s3.prefix";
     public static final String AWS_STS_ROLE_ARN = "aws.sts.role.arn";
     public static final String AWS_STS_ROLE_EXTERNAL_ID = "aws.sts.role.external.id";
@@ -220,11 +219,6 @@ public final class S3ConfigFragment extends ConfigFragment {
         configDef.define(AWS_S3_PREFIX_CONFIG, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
                 ConfigDef.Importance.MEDIUM, "Prefix for stored objects, e.g. cluster-1/", GROUP_AWS, awsGroupCounter++,
                 ConfigDef.Width.NONE, AWS_S3_PREFIX_CONFIG);
-
-        configDef.define(AWS_S3_START_AFTER_CONFIG, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
-                ConfigDef.Importance.MEDIUM,
-                "If you want to start reading events from a specific location you can start reading them after a certain file name in S3 by configuring this.",
-                GROUP_AWS, awsGroupCounter++, ConfigDef.Width.NONE, AWS_S3_START_AFTER_CONFIG);
 
         configDef.define(FETCH_PAGE_SIZE, ConfigDef.Type.INT, 10, ConfigDef.Range.atLeast(1),
                 ConfigDef.Importance.MEDIUM, "AWS S3 Fetch page size", GROUP_AWS, awsGroupCounter++, // NOPMD

--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationTest.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationTest.java
@@ -77,6 +77,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.platform.commons.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -253,7 +254,8 @@ final class IntegrationTest implements IntegrationBase {
         final var topicName = IntegrationBase.topicName(testInfo);
 
         final String partition = "00000";
-        final String fileName = topicName + "-" + partition + "-" + System.currentTimeMillis() + ".txt";
+        final String fileName = addPrefixOrDefault("") + topicName + "-" + partition + "-" + System.currentTimeMillis()
+                + ".txt";
         final String name = "testuser";
 
         final Map<String, String> connectorConfig = getAvroConfig(topicName, InputFormat.PARQUET);
@@ -337,11 +339,16 @@ final class IntegrationTest implements IntegrationBase {
     }
 
     private static String writeToS3(final String topicName, final byte[] testDataBytes, final String partitionId) {
-        final String objectKey = topicName + "-" + partitionId + "-" + System.currentTimeMillis() + ".txt";
+        final String objectKey = addPrefixOrDefault("") + topicName + "-" + partitionId + "-"
+                + System.currentTimeMillis() + ".txt";
         final PutObjectRequest request = new PutObjectRequest(TEST_BUCKET_NAME, objectKey,
                 new ByteArrayInputStream(testDataBytes), new ObjectMetadata());
         s3Client.putObject(request);
         return OBJECT_KEY + SEPARATOR + objectKey;
+    }
+
+    private static String addPrefixOrDefault(final String defaultValue) {
+        return StringUtils.isNotBlank(s3Prefix) ? s3Prefix : defaultValue;
     }
 
     private Map<String, String> getConfig(final String connectorName, final String topics, final int maxTasks) {

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/AWSV2SourceClient.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/AWSV2SourceClient.java
@@ -94,9 +94,8 @@ public class AWSV2SourceClient {
                 .iterate(s3Client.listObjectsV2(request), Objects::nonNull, response -> {
                     // This is called every time next() is called on the iterator.
                     if (response.isTruncated()) {
-                        return s3Client.listObjectsV2(new ListObjectsV2Request().withBucketName(bucketName)
-                                .withMaxKeys(s3SourceConfig.getS3ConfigFragment().getFetchPageSize() * PAGE_SIZE_FACTOR)
-                                .withContinuationToken(response.getNextContinuationToken()));
+                        return s3Client.listObjectsV2(
+                                new ListObjectsV2Request().withContinuationToken(response.getNextContinuationToken()));
                     } else {
                         return null;
                     }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/AWSV2SourceClient.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/AWSV2SourceClient.java
@@ -85,6 +85,10 @@ public class AWSV2SourceClient {
         if (StringUtils.isNotBlank(startToken)) {
             request.withStartAfter(startToken);
         }
+        // Prefix is optional so only use if supplied
+        if (StringUtils.isNotBlank(s3SourceConfig.getAwsS3Prefix())) {
+            request.withPrefix(s3SourceConfig.getAwsS3Prefix());
+        }
 
         final Stream<String> s3ObjectKeyStream = Stream
                 .iterate(s3Client.listObjectsV2(request), Objects::nonNull, response -> {


### PR DESCRIPTION
* This update means we can now use the PREFIX in the AWS API allowing users to configure it to be more specific about what they want processed by the connector.