### PR TITLE
Transformer streaming fix

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/connect/common/source/input/ByteArrayTransformer.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/source/input/ByteArrayTransformer.java
@@ -18,20 +18,21 @@ package io.aiven.kafka.connect.common.source.input;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Map;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
+import java.util.function.Consumer;
 
 import org.apache.kafka.common.config.AbstractConfig;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.function.IOSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ByteArrayTransformer implements Transformer {
+public class ByteArrayTransformer extends Transformer<byte[]> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ByteArrayTransformer.class);
+
+    private static final int MAX_BUFFER_SIZE = 4096;
 
     @Override
     public void configureValueConverter(final Map<String, String> config, final AbstractConfig sourceConfig) {
@@ -39,49 +40,43 @@ public class ByteArrayTransformer implements Transformer {
     }
 
     @Override
-    public Stream<Object> getRecords(final IOSupplier<InputStream> inputStreamIOSupplier, final String topic,
-            final int topicPartition, final AbstractConfig sourceConfig, final long skipRecords) {
-
-        // Create a Stream that processes each chunk lazily
-        return StreamSupport.stream(new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
-            final byte[] buffer = new byte[4096];
-            InputStream inputStream;
-
-            {
-                try {
-                    inputStream = inputStreamIOSupplier.get(); // Open the InputStream once
-                } catch (IOException e) {
-                    LOGGER.error("Error closing stream: {}", e.getMessage(), e);
-                }
+    public StreamSpliterator<byte[]> createSpliterator(final IOSupplier<InputStream> inputStreamIOSupplier,
+            final String topic, final int topicPartition, final AbstractConfig sourceConfig) {
+        return new StreamSpliterator<byte[]>(LOGGER, inputStreamIOSupplier) {
+            @Override
+            protected InputStream inputOpened(final InputStream input) {
+                return input;
             }
 
             @Override
-            public boolean tryAdvance(final java.util.function.Consumer<? super Object> action) {
+            protected void doClose() {
+                // nothing to do.
+            }
+
+            @Override
+            protected boolean doAdvance(final Consumer<? super byte[]> action) {
+                final byte[] buffer = new byte[MAX_BUFFER_SIZE];
                 try {
-                    final int bytesRead = inputStream.read(buffer);
-                    if (bytesRead == -1) {
+                    final int bytesRead = IOUtils.read(inputStream, buffer);
+                    if (bytesRead == 0) {
                         return false;
                     }
-                    final byte[] chunk = new byte[bytesRead];
-                    System.arraycopy(buffer, 0, chunk, 0, bytesRead);
-                    action.accept(chunk);
+                    if (bytesRead < MAX_BUFFER_SIZE) {
+                        action.accept(Arrays.copyOf(buffer, bytesRead));
+                    } else {
+                        action.accept(buffer);
+                    }
                     return true;
                 } catch (IOException e) {
-                    LOGGER.error("Error trying to advance byte stream: {}", e.getMessage(), e);
+                    LOGGER.error("Error trying to advance inputStream: {}", e.getMessage(), e);
                     return false;
                 }
             }
-        }, false).onClose(() -> {
-            try {
-                inputStreamIOSupplier.get().close(); // Ensure the reader is closed after streaming
-            } catch (IOException e) {
-                LOGGER.error("Error closing BufferedReader: {}", e.getMessage(), e);
-            }
-        });
+        };
     }
 
     @Override
-    public byte[] getValueBytes(final Object record, final String topic, final AbstractConfig sourceConfig) {
-        return (byte[]) record;
+    public byte[] getValueBytes(final byte[] record, final String topic, final AbstractConfig sourceConfig) {
+        return record;
     }
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/source/input/Transformer.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/source/input/Transformer.java
@@ -16,20 +16,168 @@
 
 package io.aiven.kafka.connect.common.source.input;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.Spliterator;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.apache.kafka.common.config.AbstractConfig;
 
 import org.apache.commons.io.function.IOSupplier;
+import org.slf4j.Logger;
 
-public interface Transformer {
+public abstract class Transformer<T> {
 
-    void configureValueConverter(Map<String, String> config, AbstractConfig sourceConfig);
+    public abstract void configureValueConverter(Map<String, String> config, AbstractConfig sourceConfig);
 
-    Stream<Object> getRecords(IOSupplier<InputStream> inputStreamIOSupplier, String topic, int topicPartition,
-            AbstractConfig sourceConfig, long skipRecords);
+    public final Stream<T> getRecords(final IOSupplier<InputStream> inputStreamIOSupplier, final String topic,
+            final int topicPartition, final AbstractConfig sourceConfig, final long skipRecords) {
 
-    byte[] getValueBytes(Object record, String topic, AbstractConfig sourceConfig);
+        final StreamSpliterator<T> spliterator = createSpliterator(inputStreamIOSupplier, topic, topicPartition,
+                sourceConfig);
+        return StreamSupport.stream(spliterator, false).onClose(spliterator::close).skip(skipRecords);
+    }
+
+    /**
+     * Creates the stream spliterator for this transformer.
+     *
+     * @param inputStreamIOSupplier
+     *            the input stream supplier.
+     * @param topic
+     *            the topic.
+     * @param topicPartition
+     *            the partition.
+     * @param sourceConfig
+     *            the source configuraiton.
+     * @return a StreamSpliterator instance.
+     */
+    protected abstract StreamSpliterator<T> createSpliterator(IOSupplier<InputStream> inputStreamIOSupplier,
+            String topic, int topicPartition, AbstractConfig sourceConfig);
+
+    public abstract byte[] getValueBytes(T record, String topic, AbstractConfig sourceConfig);
+
+    /**
+     * A Spliterator that performs various checks on the opening/closing of the input stream.
+     *
+     * @param <T>
+     *            the type of item created by this Spliterator.
+     */
+    protected abstract static class StreamSpliterator<T> implements Spliterator<T> {
+        /**
+         * The input stream supplier.
+         */
+        private final IOSupplier<InputStream> inputStreamIOSupplier;
+        /**
+         * The logger to be used by all instances of this class. This will be the Transformer logger.
+         */
+        protected final Logger logger;
+        /**
+         * The input stream. Will be null until {@link #inputOpened} has completed. May be used for reading but should
+         * not be closed or otherwise made unreadable.
+         */
+        protected InputStream inputStream;
+
+        /**
+         * A flag indicate that the input stream has been closed.
+         */
+        private boolean closed;
+
+        /**
+         * Constructor.
+         *
+         * @param logger
+         *            The logger for this Spliterator to use.
+         * @param inputStreamIOSupplier
+         *            the InputStream supplier
+         */
+        protected StreamSpliterator(final Logger logger, final IOSupplier<InputStream> inputStreamIOSupplier) {
+            this.logger = logger;
+            this.inputStreamIOSupplier = inputStreamIOSupplier;
+        }
+
+        /**
+         * Attempt to read the next record. If there is no record to read or an error occurred return false. If a record
+         * was created, call {@code action.accept()} with the record.
+         *
+         * @param action
+         *            the Consumer to call if record is created.
+         * @return {@code true} if a record was processed, {@code false} otherwise.
+         */
+        abstract protected boolean doAdvance(Consumer<? super T> action);
+
+        /**
+         * Method to close additional inputs if needed.
+         */
+        abstract protected void doClose();
+
+        public final void close() {
+            doClose();
+            try {
+                if (inputStream != null) {
+                    inputStream.close();
+                    closed = true;
+                }
+            } catch (IOException e) {
+                logger.error("Error trying to close inputStream: {}", e.getMessage(), e);
+            }
+        }
+
+        /**
+         * Allows modification of input stream. Called immediatly after the input stream is opened. Implementations may
+         * modify the type of input stream by wrapping it with a specific implementation, or may create Readers from the
+         * input stream. The modified input stream must be returned. If a Reader or similar class is created from the
+         * input stream the input stream must be returned.
+         *
+         * @param input
+         *            the input stream that was just opened.
+         * @return the input stream or modified input stream.
+         * @throws IOException
+         *             on IO error.
+         */
+        abstract protected InputStream inputOpened(InputStream input) throws IOException;
+
+        @Override
+        public final boolean tryAdvance(final Consumer<? super T> action) {
+            boolean result = false;
+            if (closed) {
+                logger.error("Attempt to advance after closed");
+            }
+            try {
+                if (inputStream == null) {
+                    try {
+                        inputStream = inputOpened(inputStreamIOSupplier.get());
+                    } catch (IOException e) {
+                        logger.error("Error trying to open inputStream: {}", e.getMessage(), e);
+                        close();
+                        return false;
+                    }
+                }
+                result = doAdvance(action);
+            } catch (RuntimeException e) { // NOPMD must catch runtime exception here.
+                logger.error("Error trying to advance data: {}", e.getMessage(), e);
+            }
+            if (!result) {
+                close();
+            }
+            return result;
+        }
+
+        @Override
+        public final Spliterator<T> trySplit() { // NOPMD returning null is reqruied by API
+            return null;
+        }
+
+        @Override
+        public long estimateSize() {
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public int characteristics() {
+            return Spliterator.ORDERED | Spliterator.NONNULL;
+        }
+    }
 }

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/input/AvroTransformerTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/input/AvroTransformerTest.java
@@ -74,7 +74,8 @@ final class AvroTransformerTest {
     void testReadAvroRecordsInvalidData() {
         final InputStream inputStream = new ByteArrayInputStream("mock-avro-data".getBytes(StandardCharsets.UTF_8));
 
-        final Stream<Object> records = avroTransformer.getRecords(() -> inputStream, "", 0, sourceCommonConfig, 0);
+        final Stream<GenericRecord> records = avroTransformer.getRecords(() -> inputStream, "", 0, sourceCommonConfig,
+                0);
 
         final List<Object> recs = records.collect(Collectors.toList());
         assertThat(recs).isEmpty();
@@ -85,7 +86,8 @@ final class AvroTransformerTest {
         final ByteArrayOutputStream avroData = generateMockAvroData(25);
         final InputStream inputStream = new ByteArrayInputStream(avroData.toByteArray());
 
-        final Stream<Object> records = avroTransformer.getRecords(() -> inputStream, "", 0, sourceCommonConfig, 0);
+        final Stream<GenericRecord> records = avroTransformer.getRecords(() -> inputStream, "", 0, sourceCommonConfig,
+                0);
 
         final List<Object> recs = records.collect(Collectors.toList());
         assertThat(recs).hasSize(25);
@@ -96,7 +98,8 @@ final class AvroTransformerTest {
         final ByteArrayOutputStream avroData = generateMockAvroData(20);
         final InputStream inputStream = new ByteArrayInputStream(avroData.toByteArray());
 
-        final Stream<Object> records = avroTransformer.getRecords(() -> inputStream, "", 0, sourceCommonConfig, 5);
+        final Stream<GenericRecord> records = avroTransformer.getRecords(() -> inputStream, "", 0, sourceCommonConfig,
+                5);
 
         final List<Object> recs = records.collect(Collectors.toList());
         assertThat(recs).hasSize(15);
@@ -110,13 +113,14 @@ final class AvroTransformerTest {
         final ByteArrayOutputStream avroData = generateMockAvroData(20);
         final InputStream inputStream = new ByteArrayInputStream(avroData.toByteArray());
 
-        final Stream<Object> records = avroTransformer.getRecords(() -> inputStream, "", 0, sourceCommonConfig, 25);
+        final Stream<GenericRecord> records = avroTransformer.getRecords(() -> inputStream, "", 0, sourceCommonConfig,
+                25);
 
         final List<Object> recs = records.collect(Collectors.toList());
         assertThat(recs).hasSize(0);
     }
 
-    ByteArrayOutputStream generateMockAvroData(final int numRecs) throws IOException {
+    static ByteArrayOutputStream generateMockAvroData(final int numRecs) throws IOException {
         final String schemaJson = "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"TestRecord\",\n"
                 + "  \"fields\": [\n" + "    {\"name\": \"message\", \"type\": \"string\"},\n"
                 + "    {\"name\": \"id\", \"type\": \"int\"}\n" + "  ]\n" + "}";

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/input/ByteArrayTransformerTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/input/ByteArrayTransformerTest.java
@@ -53,7 +53,7 @@ final class ByteArrayTransformerTest {
         final InputStream inputStream = new ByteArrayInputStream(data);
         final IOSupplier<InputStream> inputStreamIOSupplier = () -> inputStream;
 
-        final Stream<Object> records = byteArrayTransformer.getRecords(inputStreamIOSupplier, TEST_TOPIC, 0,
+        final Stream<byte[]> records = byteArrayTransformer.getRecords(inputStreamIOSupplier, TEST_TOPIC, 0,
                 sourceCommonConfig, 0);
 
         final List<Object> recs = records.collect(Collectors.toList());
@@ -67,7 +67,7 @@ final class ByteArrayTransformerTest {
 
         final IOSupplier<InputStream> inputStreamIOSupplier = () -> inputStream;
 
-        final Stream<Object> records = byteArrayTransformer.getRecords(inputStreamIOSupplier, TEST_TOPIC, 0,
+        final Stream<byte[]> records = byteArrayTransformer.getRecords(inputStreamIOSupplier, TEST_TOPIC, 0,
                 sourceCommonConfig, 0);
 
         assertThat(records).hasSize(0);

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/input/JsonTransformerTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/input/JsonTransformerTest.java
@@ -73,7 +73,7 @@ final class JsonTransformerTest {
         final InputStream validJsonInputStream = new ByteArrayInputStream(
                 "{\"key\":\"value\"}".getBytes(StandardCharsets.UTF_8));
         final IOSupplier<InputStream> inputStreamIOSupplier = () -> validJsonInputStream;
-        final Stream<Object> jsonNodes = jsonTransformer.getRecords(inputStreamIOSupplier, TESTTOPIC, 1,
+        final Stream<JsonNode> jsonNodes = jsonTransformer.getRecords(inputStreamIOSupplier, TESTTOPIC, 1,
                 sourceCommonConfig, 0);
 
         assertThat(jsonNodes).hasSize(1);
@@ -84,7 +84,7 @@ final class JsonTransformerTest {
         final InputStream validJsonInputStream = new ByteArrayInputStream(
                 getJsonRecs(100).getBytes(StandardCharsets.UTF_8));
         final IOSupplier<InputStream> inputStreamIOSupplier = () -> validJsonInputStream;
-        final Stream<Object> jsonNodes = jsonTransformer.getRecords(inputStreamIOSupplier, TESTTOPIC, 1,
+        final Stream<JsonNode> jsonNodes = jsonTransformer.getRecords(inputStreamIOSupplier, TESTTOPIC, 1,
                 sourceCommonConfig, 25L);
 
         final List<Object> recs = jsonNodes.collect(Collectors.toList());
@@ -104,7 +104,7 @@ final class JsonTransformerTest {
                 "invalid-json".getBytes(StandardCharsets.UTF_8));
         final IOSupplier<InputStream> inputStreamIOSupplier = () -> invalidJsonInputStream;
 
-        final Stream<Object> jsonNodes = jsonTransformer.getRecords(inputStreamIOSupplier, TESTTOPIC, 1,
+        final Stream<JsonNode> jsonNodes = jsonTransformer.getRecords(inputStreamIOSupplier, TESTTOPIC, 1,
                 sourceCommonConfig, 0);
 
         assertThat(jsonNodes).isEmpty();
@@ -115,7 +115,7 @@ final class JsonTransformerTest {
         final InputStream validJsonInputStream = new ByteArrayInputStream(
                 "{\"key\":\"value\"}".getBytes(StandardCharsets.UTF_8));
         final IOSupplier<InputStream> inputStreamIOSupplier = () -> validJsonInputStream;
-        final Stream<Object> jsonNodes = jsonTransformer.getRecords(inputStreamIOSupplier, TESTTOPIC, 1,
+        final Stream<JsonNode> jsonNodes = jsonTransformer.getRecords(inputStreamIOSupplier, TESTTOPIC, 1,
                 sourceCommonConfig, 0);
         final byte[] serializedData = jsonTransformer.getValueBytes(jsonNodes.findFirst().get(), TESTTOPIC,
                 sourceCommonConfig);
@@ -129,30 +129,30 @@ final class JsonTransformerTest {
     @Test
     void testGetRecordsWithIOException() throws IOException {
         when(inputStreamIOSupplierMock.get()).thenThrow(new IOException("Test IOException"));
-        final Stream<Object> resultStream = jsonTransformer.getRecords(inputStreamIOSupplierMock, "topic", 0, null, 0);
+        final Stream<JsonNode> resultStream = jsonTransformer.getRecords(inputStreamIOSupplierMock, "topic", 0, null, 0);
 
         assertThat(resultStream).isEmpty();
     }
 
-    @Test
-    void testCustomSpliteratorStreamProcessing() throws IOException {
-        final String jsonContent = "{\"key\":\"value\"}\n{\"key2\":\"value2\"}";
-        final InputStream inputStream = new ByteArrayInputStream(jsonContent.getBytes(StandardCharsets.UTF_8));
-        final IOSupplier<InputStream> supplier = () -> inputStream;
-
-        final JsonTransformer.CustomSpliterator spliterator = jsonTransformer.new CustomSpliterator(supplier);
-        assertThat(spliterator.tryAdvance(jsonNode -> assertThat(jsonNode).isNotNull())).isTrue();
-    }
+    // @Test
+    // void testCustomSpliteratorStreamProcessing() throws IOException {
+    // final String jsonContent = "{\"key\":\"value\"}\n{\"key2\":\"value2\"}";
+    // final InputStream inputStream = new ByteArrayInputStream(jsonContent.getBytes(StandardCharsets.UTF_8));
+    // final IOSupplier<InputStream> supplier = () -> inputStream;
+    //
+    // final JsonTransformer.CustomSpliterator spliterator = jsonTransformer.new CustomSpliterator(supplier);
+    // assertThat(spliterator.tryAdvance(jsonNode -> assertThat(jsonNode).isNotNull())).isTrue();
+    // }
 
     @Test
     void testCustomSpliteratorWithIOExceptionDuringInitialization() throws IOException {
         when(inputStreamIOSupplierMock.get()).thenThrow(new IOException("Test IOException during initialization"));
-        final Stream<Object> resultStream = jsonTransformer.getRecords(inputStreamIOSupplierMock, "topic", 0, null, 0);
+        final Stream<JsonNode> resultStream = jsonTransformer.getRecords(inputStreamIOSupplierMock, "topic", 0, null, 0);
 
         assertThat(resultStream).isEmpty();
     }
 
-    String getJsonRecs(final int recordCount) {
+    static String getJsonRecs(final int recordCount) {
         final StringBuilder jsonRecords = new StringBuilder();
         for (int i = 1; i <= recordCount; i++) {
             jsonRecords.append(String.format("{\"key\":\"value%d\"}", i));

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/input/JsonTransformerTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/input/JsonTransformerTest.java
@@ -134,16 +134,6 @@ final class JsonTransformerTest {
         assertThat(resultStream).isEmpty();
     }
 
-    // @Test
-    // void testCustomSpliteratorStreamProcessing() throws IOException {
-    // final String jsonContent = "{\"key\":\"value\"}\n{\"key2\":\"value2\"}";
-    // final InputStream inputStream = new ByteArrayInputStream(jsonContent.getBytes(StandardCharsets.UTF_8));
-    // final IOSupplier<InputStream> supplier = () -> inputStream;
-    //
-    // final JsonTransformer.CustomSpliterator spliterator = jsonTransformer.new CustomSpliterator(supplier);
-    // assertThat(spliterator.tryAdvance(jsonNode -> assertThat(jsonNode).isNotNull())).isTrue();
-    // }
-
     @Test
     void testCustomSpliteratorWithIOExceptionDuringInitialization() throws IOException {
         when(inputStreamIOSupplierMock.get()).thenThrow(new IOException("Test IOException during initialization"));

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/input/ParquetTransformerTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/input/ParquetTransformerTest.java
@@ -62,7 +62,7 @@ final class ParquetTransformerTest {
 
         final String topic = "test-topic";
         final int topicPartition = 0;
-        final Stream<Object> recs = parquetTransformer.getRecords(inputStreamIOSupplier, topic, topicPartition,
+        final Stream<GenericRecord> recs = parquetTransformer.getRecords(inputStreamIOSupplier, topic, topicPartition,
                 s3SourceConfig, 0L);
 
         assertThat(recs).isEmpty();
@@ -123,8 +123,8 @@ final class ParquetTransformerTest {
         final String topic = "test-topic";
         final int topicPartition = 0;
 
-        final Stream<Object> records = parquetTransformer.getRecords(inputStreamIOSupplier, topic, topicPartition,
-                s3SourceConfig, 0L);
+        final Stream<GenericRecord> records = parquetTransformer.getRecords(inputStreamIOSupplier, topic,
+                topicPartition, s3SourceConfig, 0L);
         assertThat(records).isEmpty();
     }
 
@@ -137,7 +137,7 @@ final class ParquetTransformerTest {
         assertThat(Files.exists(tempFile)).isFalse();
     }
 
-    private byte[] generateMockParquetData() throws IOException {
+    static byte[] generateMockParquetData() throws IOException {
         final Path path = ContentUtils.getTmpFilePath("name");
         return IOUtils.toByteArray(Files.newInputStream(path));
     }
@@ -149,8 +149,8 @@ final class ParquetTransformerTest {
                     .thenThrow(new IOException("Test IOException for temp file"));
 
             final IOSupplier<InputStream> inputStreamSupplier = mock(IOSupplier.class);
-            final Stream<Object> resultStream = parquetTransformer.getRecords(inputStreamSupplier, "test-topic", 1,
-                    null, 0L);
+            final Stream<GenericRecord> resultStream = parquetTransformer.getRecords(inputStreamSupplier, "test-topic",
+                    1, null, 0L);
 
             assertThat(resultStream).isEmpty();
         }
@@ -162,8 +162,8 @@ final class ParquetTransformerTest {
             when(inputStreamMock.read(any(byte[].class))).thenThrow(new IOException("Test IOException during copy"));
 
             final IOSupplier<InputStream> inputStreamSupplier = () -> inputStreamMock;
-            final Stream<Object> resultStream = parquetTransformer.getRecords(inputStreamSupplier, "test-topic", 1,
-                    null, 0L);
+            final Stream<GenericRecord> resultStream = parquetTransformer.getRecords(inputStreamSupplier, "test-topic",
+                    1, null, 0L);
 
             assertThat(resultStream).isEmpty();
         }

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/input/TransformerStreamingTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/input/TransformerStreamingTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.source.input;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import io.aiven.kafka.connect.common.config.CommonConfig;
+
+import org.apache.commons.io.function.IOSupplier;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Abstract test class to verify that streaming data is closed properly.
+ */
+class TransformerStreamingTest {
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    void verifyExceptionDuringIOOpen(final Transformer<?> transformer, final byte[] testData,
+            final AbstractConfig config, final int expectedCount) throws IOException {
+        final IOSupplier<InputStream> ioSupplier = mock(IOSupplier.class);
+        when(ioSupplier.get()).thenThrow(new IOException("Test IOException during initialization"));
+        final Stream<?> objStream = transformer.getRecords(ioSupplier, "topic", 1, config, 0);
+        assertThat(objStream).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    void verifyCloseCalledAtEnd(final Transformer<?> transformer, final byte[] testData, final AbstractConfig config,
+            final int expectedCount) throws IOException {
+        final CloseTrackingStream stream = new CloseTrackingStream(new ByteArrayInputStream(testData));
+        final Stream<?> objStream = transformer.getRecords(() -> stream, "topic", 1, config, 0);
+        final long count = objStream.count();
+        assertThat(count).isEqualTo(expectedCount);
+        assertThat(stream.closeCount).isGreaterThan(0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    void verifyCloseCalledAtIteratorEnd(final Transformer<?> transformer, final byte[] testData,
+            final AbstractConfig config, final int expectedCount) throws IOException {
+        final CloseTrackingStream stream = new CloseTrackingStream(new ByteArrayInputStream(testData));
+        final Stream<?> objStream = transformer.getRecords(() -> stream, "topic", 1, config, 0);
+        final Iterator<?> iter = objStream.iterator();
+        long count = 0L;
+        while (iter.hasNext()) {
+            count += 1;
+            iter.next();
+        }
+        assertThat(count).isEqualTo(expectedCount);
+        assertThat(stream.closeCount).isGreaterThan(0);
+    }
+
+    static Stream<Arguments> testData() throws IOException {
+        final List<Arguments> lst = new ArrayList<>();
+        lst.add(Arguments.of(new AvroTransformer(), AvroTransformerTest.generateMockAvroData(100).toByteArray(),
+                new CommonConfig(new ConfigDef(), new HashMap<>()) {
+                }, 100));
+        lst.add(Arguments.of(new ByteArrayTransformer(), "Hello World".getBytes(StandardCharsets.UTF_8),
+                new CommonConfig(new ConfigDef(), new HashMap<>()) {
+                }, 1));
+        lst.add(Arguments.of(new JsonTransformer(),
+                JsonTransformerTest.getJsonRecs(100).getBytes(StandardCharsets.UTF_8),
+                new CommonConfig(new ConfigDef(), new HashMap<>()) {
+                }, 100));
+        lst.add(Arguments.of(new ParquetTransformer(), ParquetTransformerTest.generateMockParquetData(),
+                new CommonConfig(new ConfigDef(), new HashMap<>()) {
+                }, 100));
+        return lst.stream();
+    }
+
+    private static class CloseTrackingStream extends InputStream {
+        InputStream delegate;
+        int closeCount;
+
+        CloseTrackingStream(final InputStream stream) {
+            super();
+            this.delegate = stream;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (closeCount > 0) {
+                throw new IOException("ERROR Read after close");
+            }
+            return delegate.read();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCount++;
+            delegate.close();
+        }
+    }
+}


### PR DESCRIPTION
Fix for KCON-82

This PR fixes the bugs and simplifies the creation of a proper transformer by relieving the developer of having to think about the stream and just think about how to create the item.

Streaming Tests are included for all current Transformer implementations.

Transformer is converted to an abstract class.

An abstract Transformer.StreamSpliterator class is created to handle the common checking for end of stream and closing the input file(s).


