### PR TITLE
Improve S3 Source Integration tests

### DIFF
--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationTest.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationTest.java
@@ -230,12 +230,10 @@ final class IntegrationTest implements IntegrationBase {
         assertThat(testBucketAccessor.listObjects()).hasSize(5);
 
         // Poll Avro messages from the Kafka topic and deserialize them
+        // Waiting for 25k kafka records in this test so a longer Duration is added.
         final List<GenericRecord> records = IntegrationBase.consumeAvroMessages(topicName, numOfRecsFactor * 5,
-                Duration.ofMinutes(3), connectRunner.getBootstrapServers(), schemaRegistry.getSchemaRegistryUrl()); // Ensure
-                                                                                                                    // this
-                                                                                                                    // method
-                                                                                                                    // deserializes
-                                                                                                                    // Avro
+                Duration.ofMinutes(3), connectRunner.getBootstrapServers(), schemaRegistry.getSchemaRegistryUrl());
+        // Ensure this method deserializes Avro
 
         // Verify that the correct data is read from the S3 bucket and pushed to Kafka
         assertThat(records).map(record -> entry(record.get("id"), String.valueOf(record.get("message"))))
@@ -272,6 +270,7 @@ final class IntegrationTest implements IntegrationBase {
             Files.delete(path);
         }
 
+        // Waiting for a small number of messages so using a smaller Duration of a minute
         final List<GenericRecord> records = IntegrationBase.consumeAvroMessages(topicName, 100, Duration.ofSeconds(60),
                 connectRunner.getBootstrapServers(), schemaRegistry.getSchemaRegistryUrl());
         final List<String> expectedRecordNames = IntStream.range(0, 100)

--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationTest.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationTest.java
@@ -231,8 +231,11 @@ final class IntegrationTest implements IntegrationBase {
 
         // Poll Avro messages from the Kafka topic and deserialize them
         final List<GenericRecord> records = IntegrationBase.consumeAvroMessages(topicName, numOfRecsFactor * 5,
-                connectRunner.getBootstrapServers(), schemaRegistry.getSchemaRegistryUrl()); // Ensure this method
-                                                                                             // deserializes Avro
+                Duration.ofMinutes(3), connectRunner.getBootstrapServers(), schemaRegistry.getSchemaRegistryUrl()); // Ensure
+                                                                                                                    // this
+                                                                                                                    // method
+                                                                                                                    // deserializes
+                                                                                                                    // Avro
 
         // Verify that the correct data is read from the S3 bucket and pushed to Kafka
         assertThat(records).map(record -> entry(record.get("id"), String.valueOf(record.get("message"))))
@@ -269,7 +272,7 @@ final class IntegrationTest implements IntegrationBase {
             Files.delete(path);
         }
 
-        final List<GenericRecord> records = IntegrationBase.consumeAvroMessages(topicName, 100,
+        final List<GenericRecord> records = IntegrationBase.consumeAvroMessages(topicName, 100, Duration.ofSeconds(60),
                 connectRunner.getBootstrapServers(), schemaRegistry.getSchemaRegistryUrl());
         final List<String> expectedRecordNames = IntStream.range(0, 100)
                 .mapToObj(i -> name + i)


### PR DESCRIPTION
Increase performance of the S3 Integration tests by allowing the polling time to be dependent on the test and to take into account if their are more records left to be retrieved before waiting to collect the next batch of records.

This allows the consuming of messages to occur faster if additional messages are already waiting to be retrieved.
This allows different tests to allow a more subtle control of the time to wait before timing out. (previously all tests would wait the maximum 5 minutes even if only waiting for 5 messages from kafka)

This should save 2-3 minutes per Integration test run and allow on a failure run to save between 12-15 minutes on each test run.