### PR TITLE
Revert "Release version 3.2.0"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.3.0-SNAPSHOT
+version=3.2.0-SNAPSHOT
 
 sonatypeUsername=<fill>
 sonatypePassword=<fill>


### PR DESCRIPTION
Reverts Aiven-Open/cloud-storage-connectors-for-apache-kafka#409

The PR have been squashed but we need both commits, let's revert it and re-run the action