### PR TITLE
Clean up config

### DIFF
--- a/azure-sink-connector/src/main/java/io/aiven/kafka/connect/azure/sink/AzureBlobSinkConfig.java
+++ b/azure-sink-connector/src/main/java/io/aiven/kafka/connect/azure/sink/AzureBlobSinkConfig.java
@@ -35,6 +35,7 @@ import io.aiven.kafka.connect.common.config.FixedSetRecommender;
 import io.aiven.kafka.connect.common.config.OutputField;
 import io.aiven.kafka.connect.common.config.OutputFieldEncodingType;
 import io.aiven.kafka.connect.common.config.OutputFieldType;
+import io.aiven.kafka.connect.common.config.OutputFormatFragment;
 import io.aiven.kafka.connect.common.config.TimestampSource;
 import io.aiven.kafka.connect.common.config.validators.FilenameTemplateValidator;
 
@@ -76,8 +77,7 @@ public final class AzureBlobSinkConfig extends AivenCommonConfig {
         final ConfigDef configDef = new ConfigDef();
         addAzureConfigGroup(configDef);
         addFileConfigGroup(configDef);
-        addOutputFieldsFormatConfigGroup(configDef, OutputFieldType.VALUE);
-        addKafkaBackoffPolicy(configDef);
+        OutputFormatFragment.update(configDef, OutputFieldType.VALUE);
         addAzureRetryPolicies(configDef);
         addUserAgentConfig(configDef);
         return configDef;

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SinkCommonConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SinkCommonConfig.java
@@ -55,7 +55,6 @@ public class SinkCommonConfig extends CommonConfig {
         fileNameFragment.validate();
     }
 
-
     public FormatType getFormatType() {
         return outputFormatFragment.getFormatType();
     }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SinkCommonConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SinkCommonConfig.java
@@ -55,10 +55,6 @@ public class SinkCommonConfig extends CommonConfig {
         fileNameFragment.validate();
     }
 
-    protected static void addOutputFieldsFormatConfigGroup(final ConfigDef configDef,
-            final OutputFieldType defaultFieldType) {
-        OutputFormatFragment.update(configDef, defaultFieldType);
-    }
 
     public FormatType getFormatType() {
         return outputFormatFragment.getFormatType();

--- a/commons/src/test/java/io/aiven/kafka/connect/common/config/AivenCommonConfigTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/config/AivenCommonConfigTest.java
@@ -16,7 +16,6 @@
 
 package io.aiven.kafka.connect.common.config;
 
-import static io.aiven.kafka.connect.common.config.AivenCommonConfig.addOutputFieldsFormatConfigGroup;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -31,7 +30,7 @@ class AivenCommonConfigTest {
 
     private ConfigDef getBaseConfigDefinition() {
         final ConfigDef definition = new ConfigDef();
-        addOutputFieldsFormatConfigGroup(definition, OutputFieldType.VALUE);
+        OutputFormatFragment.update(definition, OutputFieldType.VALUE);
 
         definition.define(AivenCommonConfig.FILE_NAME_TEMPLATE_CONFIG, ConfigDef.Type.STRING, null,
                 ConfigDef.Importance.MEDIUM, "File name template");
@@ -78,7 +77,7 @@ class AivenCommonConfigTest {
                 "false");
 
         final ConfigDef definition = new ConfigDef();
-        addOutputFieldsFormatConfigGroup(definition, OutputFieldType.VALUE);
+        OutputFormatFragment.update(definition, OutputFieldType.VALUE);
 
         assertThatThrownBy(() -> new AivenCommonConfig(definition, properties)).isInstanceOf(ConfigException.class)
                 .hasMessage("When format.output.envelope is false, format.output.fields must contain only one field");

--- a/gcs-sink-connector/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
+++ b/gcs-sink-connector/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
@@ -38,6 +38,7 @@ import io.aiven.kafka.connect.common.config.FixedSetRecommender;
 import io.aiven.kafka.connect.common.config.OutputField;
 import io.aiven.kafka.connect.common.config.OutputFieldEncodingType;
 import io.aiven.kafka.connect.common.config.OutputFieldType;
+import io.aiven.kafka.connect.common.config.OutputFormatFragment;
 import io.aiven.kafka.connect.common.config.TimestampSource;
 import io.aiven.kafka.connect.common.config.validators.FilenameTemplateValidator;
 
@@ -103,8 +104,7 @@ public final class GcsSinkConfig extends AivenCommonConfig {
         final GcsSinkConfigDef configDef = new GcsSinkConfigDef();
         addGcsConfigGroup(configDef);
         addFileConfigGroup(configDef);
-        addOutputFieldsFormatConfigGroup(configDef, OutputFieldType.VALUE);
-        addKafkaBackoffPolicy(configDef);
+        OutputFormatFragment.update(configDef, OutputFieldType.VALUE);
         addGcsRetryPolicies(configDef);
         addUserAgentConfig(configDef);
         return configDef;

--- a/s3-commons/src/test/java/io/aiven/kafka/connect/tools/AwsCredentialBaseConfig.java
+++ b/s3-commons/src/test/java/io/aiven/kafka/connect/tools/AwsCredentialBaseConfig.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.config.ConfigDef;
 
 import io.aiven.kafka.connect.common.config.CompressionType;
 import io.aiven.kafka.connect.common.config.OutputFieldType;
+import io.aiven.kafka.connect.common.config.OutputFormatFragment;
 import io.aiven.kafka.connect.config.s3.S3ConfigFragment;
 import io.aiven.kafka.connect.config.s3.S3SinkBaseConfig;
 
@@ -38,7 +39,7 @@ public class AwsCredentialBaseConfig extends S3SinkBaseConfig {
 
     private static ConfigDef getBaseConfigDefinition() {
         final ConfigDef definition = new ConfigDef();
-        addOutputFieldsFormatConfigGroup(definition, OutputFieldType.VALUE);
+        OutputFormatFragment.update(definition, OutputFieldType.VALUE);
         definition.define(FILE_NAME_TEMPLATE_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM,
                 "File name template");
         definition.define(FILE_COMPRESSION_TYPE_CONFIG, ConfigDef.Type.STRING, CompressionType.NONE.name,

--- a/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkConnector.java
+++ b/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkConnector.java
@@ -21,10 +21,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import io.aiven.kafka.connect.s3.config.S3SinkConfigDef;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
+
+import io.aiven.kafka.connect.s3.config.S3SinkConfigDef;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkConnector.java
+++ b/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkConnector.java
@@ -21,11 +21,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import io.aiven.kafka.connect.s3.config.S3SinkConfigDef;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
-
-import io.aiven.kafka.connect.s3.config.S3SinkConfig;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +37,7 @@ public class AivenKafkaConnectS3SinkConnector extends SinkConnector {
 
     @Override
     public ConfigDef config() {
-        return S3SinkConfig.configDef();
+        return new S3SinkConfigDef();
     }
 
     @Override

--- a/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfig.java
+++ b/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfig.java
@@ -17,7 +17,6 @@
 package io.aiven.kafka.connect.s3.config;
 
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -25,23 +24,17 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.Importance;
-import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.connect.common.config.CompressionType;
-import io.aiven.kafka.connect.common.config.FileNameFragment;
 import io.aiven.kafka.connect.common.config.OutputField;
 import io.aiven.kafka.connect.common.config.OutputFieldEncodingType;
 import io.aiven.kafka.connect.common.config.OutputFieldType;
 import io.aiven.kafka.connect.common.config.TimestampSource;
-import io.aiven.kafka.connect.common.config.validators.TimeZoneValidator;
-import io.aiven.kafka.connect.common.config.validators.TimestampSourceValidator;
 import io.aiven.kafka.connect.common.templating.Template;
 import io.aiven.kafka.connect.config.s3.S3CommonConfig;
 import io.aiven.kafka.connect.config.s3.S3ConfigFragment;
 import io.aiven.kafka.connect.config.s3.S3SinkBaseConfig;
-import io.aiven.kafka.connect.s3.S3OutputStream;
 
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;

--- a/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfigDef.java
+++ b/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfigDef.java
@@ -20,17 +20,17 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigValue;
+
 import io.aiven.kafka.connect.common.config.FileNameFragment;
-import io.aiven.kafka.connect.common.config.OutputFieldType;
 import io.aiven.kafka.connect.common.config.OutputFormatFragment;
 import io.aiven.kafka.connect.common.config.TimestampSource;
 import io.aiven.kafka.connect.common.config.validators.TimeZoneValidator;
 import io.aiven.kafka.connect.common.config.validators.TimestampSourceValidator;
 import io.aiven.kafka.connect.config.s3.S3ConfigFragment;
 import io.aiven.kafka.connect.s3.S3OutputStream;
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.ConfigValue;
 
 public class S3SinkConfigDef extends ConfigDef {
 
@@ -38,10 +38,11 @@ public class S3SinkConfigDef extends ConfigDef {
     private static final String GROUP_FILE = "File";
 
     public S3SinkConfigDef() {
+        super();
         S3ConfigFragment.update(this);
         addS3partSizeConfig(this);
         FileNameFragment.update(this);
-        addOutputFieldsFormatConfigGroup(this, null);
+        OutputFormatFragment.update(this, null);
         addDeprecatedTimestampConfig(this);
     }
 
@@ -93,11 +94,6 @@ public class S3SinkConfigDef extends ConfigDef {
                 new TimestampSourceValidator(), Importance.LOW,
                 "Specifies the the timestamp variable source. Default is wall-clock.", GROUP_FILE,
                 timestampGroupCounter, ConfigDef.Width.SHORT, S3ConfigFragment.TIMESTAMP_SOURCE);
-    }
-
-    protected static void addOutputFieldsFormatConfigGroup(final ConfigDef configDef,
-                                                           final OutputFieldType defaultFieldType) {
-        OutputFormatFragment.update(configDef, defaultFieldType);
     }
 
 }

--- a/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfigDef.java
+++ b/s3-sink-connector/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfigDef.java
@@ -16,15 +16,88 @@
 
 package io.aiven.kafka.connect.s3.config;
 
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 
+import io.aiven.kafka.connect.common.config.FileNameFragment;
+import io.aiven.kafka.connect.common.config.OutputFieldType;
+import io.aiven.kafka.connect.common.config.OutputFormatFragment;
+import io.aiven.kafka.connect.common.config.TimestampSource;
+import io.aiven.kafka.connect.common.config.validators.TimeZoneValidator;
+import io.aiven.kafka.connect.common.config.validators.TimestampSourceValidator;
+import io.aiven.kafka.connect.config.s3.S3ConfigFragment;
+import io.aiven.kafka.connect.s3.S3OutputStream;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 
 public class S3SinkConfigDef extends ConfigDef {
+
+    private static final String GROUP_AWS = "AWS";
+    private static final String GROUP_FILE = "File";
+
+    public S3SinkConfigDef() {
+        S3ConfigFragment.update(this);
+        addS3partSizeConfig(this);
+        FileNameFragment.update(this);
+        addOutputFieldsFormatConfigGroup(this, null);
+        addDeprecatedTimestampConfig(this);
+    }
+
     @Override
     public List<ConfigValue> validate(final Map<String, String> props) {
         return super.validate(S3SinkConfig.preprocessProperties(props));
     }
+
+    private static void addS3partSizeConfig(final ConfigDef configDef) {
+
+        // add awsS3SinkCounter if more S3 Sink Specific config is added
+        // This is used to set orderInGroup
+        configDef.define(S3ConfigFragment.AWS_S3_PART_SIZE, Type.INT, S3OutputStream.DEFAULT_PART_SIZE,
+                new ConfigDef.Validator() {
+
+                    static final int MAX_BUFFER_SIZE = 2_000_000_000;
+
+                    @Override
+                    public void ensureValid(final String name, final Object value) {
+                        if (value == null) {
+                            throw new ConfigException(name, null, "Part size must be non-null");
+                        }
+                        final var number = (Number) value;
+                        if (number.longValue() <= 0) {
+                            throw new ConfigException(name, value, "Part size must be greater than 0");
+                        }
+                        if (number.longValue() > MAX_BUFFER_SIZE) {
+                            throw new ConfigException(name, value,
+                                    "Part size must be no more: " + MAX_BUFFER_SIZE + " bytes (2GB)");
+                        }
+                    }
+                }, Importance.MEDIUM,
+                "The Part Size in S3 Multi-part Uploads in bytes. Maximum is " + Integer.MAX_VALUE
+                        + " (2GB) and default is " + S3OutputStream.DEFAULT_PART_SIZE + " (5MB)",
+                GROUP_AWS, 0, ConfigDef.Width.NONE, S3ConfigFragment.AWS_S3_PART_SIZE);
+
+    }
+
+    private static void addDeprecatedTimestampConfig(final ConfigDef configDef) {
+        int timestampGroupCounter = 0;
+
+        configDef.define(S3ConfigFragment.TIMESTAMP_TIMEZONE, Type.STRING, ZoneOffset.UTC.toString(),
+                new TimeZoneValidator(), Importance.LOW,
+                "Specifies the timezone in which the dates and time for the timestamp variable will be treated. "
+                        + "Use standard shot and long names. Default is UTC",
+                GROUP_FILE, timestampGroupCounter++, ConfigDef.Width.SHORT, S3ConfigFragment.TIMESTAMP_TIMEZONE);
+
+        configDef.define(S3ConfigFragment.TIMESTAMP_SOURCE, Type.STRING, TimestampSource.Type.WALLCLOCK.name(),
+                new TimestampSourceValidator(), Importance.LOW,
+                "Specifies the the timestamp variable source. Default is wall-clock.", GROUP_FILE,
+                timestampGroupCounter, ConfigDef.Width.SHORT, S3ConfigFragment.TIMESTAMP_SOURCE);
+    }
+
+    protected static void addOutputFieldsFormatConfigGroup(final ConfigDef configDef,
+                                                           final OutputFieldType defaultFieldType) {
+        OutputFormatFragment.update(configDef, defaultFieldType);
+    }
+
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceConnector.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/S3SourceConnector.java
@@ -28,7 +28,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
 
-import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
+import io.aiven.kafka.connect.s3.source.config.S3SourceConfigDef;
 import io.aiven.kafka.connect.s3.source.utils.Version;
 
 import org.slf4j.Logger;
@@ -46,7 +46,7 @@ public class S3SourceConnector extends SourceConnector {
 
     @Override
     public ConfigDef config() {
-        return S3SourceConfig.configDef();
+        return new S3SourceConfigDef();
     }
 
     @Override

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfig.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfig.java
@@ -44,22 +44,10 @@ final public class S3SourceConfig extends SourceCommonConfig {
     private final S3ConfigFragment s3ConfigFragment;
     private final FileNameFragment s3FileNameFragment;
     public S3SourceConfig(final Map<String, String> properties) {
-        super(configDef(), handleDeprecatedYyyyUppercase(properties));
+        super(new S3SourceConfigDef(), handleDeprecatedYyyyUppercase(properties));
         s3ConfigFragment = new S3ConfigFragment(this);
         s3FileNameFragment = new FileNameFragment(this);
         validate(); // NOPMD ConstructorCallsOverridableMethod getStsRole is called
-    }
-
-    public static ConfigDef configDef() {
-
-        final var configDef = new S3SourceConfigDef();
-        S3ConfigFragment.update(configDef);
-        SourceConfigFragment.update(configDef);
-        FileNameFragment.update(configDef);
-        TransformerFragment.update(configDef);
-        OutputFormatFragment.update(configDef, OutputFieldType.VALUE);
-
-        return configDef;
     }
 
     private void validate() {

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfig.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfig.java
@@ -20,14 +20,8 @@ import static io.aiven.kafka.connect.config.s3.S3CommonConfig.handleDeprecatedYy
 
 import java.util.Map;
 
-import org.apache.kafka.common.config.ConfigDef;
-
 import io.aiven.kafka.connect.common.config.FileNameFragment;
-import io.aiven.kafka.connect.common.config.OutputFieldType;
-import io.aiven.kafka.connect.common.config.OutputFormatFragment;
 import io.aiven.kafka.connect.common.config.SourceCommonConfig;
-import io.aiven.kafka.connect.common.config.SourceConfigFragment;
-import io.aiven.kafka.connect.common.config.TransformerFragment;
 import io.aiven.kafka.connect.config.s3.S3ConfigFragment;
 import io.aiven.kafka.connect.iam.AwsStsEndpointConfig;
 import io.aiven.kafka.connect.iam.AwsStsRole;

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfigDef.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfigDef.java
@@ -21,18 +21,20 @@ import static io.aiven.kafka.connect.config.s3.S3CommonConfig.handleDeprecatedYy
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
+
 import io.aiven.kafka.connect.common.config.FileNameFragment;
 import io.aiven.kafka.connect.common.config.OutputFieldType;
 import io.aiven.kafka.connect.common.config.OutputFormatFragment;
 import io.aiven.kafka.connect.common.config.SourceConfigFragment;
 import io.aiven.kafka.connect.common.config.TransformerFragment;
 import io.aiven.kafka.connect.config.s3.S3ConfigFragment;
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigValue;
 
 public class S3SourceConfigDef extends ConfigDef {
 
     public S3SourceConfigDef() {
+        super();
         S3ConfigFragment.update(this);
         SourceConfigFragment.update(this);
         FileNameFragment.update(this);

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfigDef.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfigDef.java
@@ -21,10 +21,25 @@ import static io.aiven.kafka.connect.config.s3.S3CommonConfig.handleDeprecatedYy
 import java.util.List;
 import java.util.Map;
 
+import io.aiven.kafka.connect.common.config.FileNameFragment;
+import io.aiven.kafka.connect.common.config.OutputFieldType;
+import io.aiven.kafka.connect.common.config.OutputFormatFragment;
+import io.aiven.kafka.connect.common.config.SourceConfigFragment;
+import io.aiven.kafka.connect.common.config.TransformerFragment;
+import io.aiven.kafka.connect.config.s3.S3ConfigFragment;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
 
 public class S3SourceConfigDef extends ConfigDef {
+
+    public S3SourceConfigDef() {
+        S3ConfigFragment.update(this);
+        SourceConfigFragment.update(this);
+        FileNameFragment.update(this);
+        TransformerFragment.update(this);
+        OutputFormatFragment.update(this, OutputFieldType.VALUE);
+    }
+
     @Override
     public List<ConfigValue> validate(final Map<String, String> props) {
         return super.validate(handleDeprecatedYyyyUppercase(props));


### PR DESCRIPTION
fix for KCON-119

** DO NOT MERGE **
This is a draft PR to evaluate the advisability of migrating to xConfigDef constructors.

This change will make xConfigDef constructors configure the ConfigDef rather than depend on xConfig to have a method to do so.


