### PR TITLE
Add Offset Manager entry for Azure Blob

### DIFF
--- a/azure-source-connector/build.gradle.kts
+++ b/azure-source-connector/build.gradle.kts
@@ -53,8 +53,10 @@ idea {
 dependencies {
   compileOnly(apache.kafka.connect.api)
 
+  implementation("commons-io:commons-io:2.18.0")
+  implementation("org.apache.commons:commons-lang3:3.17.0")
   implementation(project(":commons"))
-
+  implementation(apache.commons.collection4)
   implementation("com.azure:azure-storage-blob:12.29.0")
 
   implementation(tools.spotbugs.annotations)

--- a/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/AzureOffsetManagerEntry.java
+++ b/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/AzureOffsetManagerEntry.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2025 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.azure.source.utils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import io.aiven.kafka.connect.common.source.OffsetManager;
+
+public final class AzureOffsetManagerEntry implements OffsetManager.OffsetManagerEntry<AzureOffsetManagerEntry> {
+
+    public static final String CONTAINER = "container";
+    public static final String BLOB_NAME = "blobName";
+    public static final String RECORD_COUNT = "recordCount";
+
+    /**
+     * THe list of Keys that may not be set via {@link #setProperty(String, Object)}.
+     */
+    static final List<String> RESTRICTED_KEYS = List.of(RECORD_COUNT);
+    /** The data map that stores all the values */
+    private final Map<String, Object> data;
+    /** THe record count for the data map. Extracted here because it is used/updated frequently during processing */
+    private long recordCount;
+
+    private final String container;
+    private final String blobName;
+
+    /**
+     * Construct the AzureOffsetManagerEntry.
+     *
+     * @param container
+     *            the bucket we are using.
+     * @param blobName
+     *            the blob name.
+     */
+    public AzureOffsetManagerEntry(final String container, final String blobName) {
+        this.container = container;
+        this.blobName = blobName;
+        data = new HashMap<>();
+    }
+
+    /**
+     * Constructs an OffsetManagerEntry from an existing map. Used to reconstitute previously serialized
+     * AzureOffsetManagerEntries. used by {@link #fromProperties(Map)}
+     *
+     * @param properties
+     *            the property map.
+     */
+    private AzureOffsetManagerEntry(final String container, final String blobName,
+            final Map<String, Object> properties) {
+        this(container, blobName);
+        data.putAll(properties);
+        final Object recordCountProperty = data.computeIfAbsent(RECORD_COUNT, s -> 0L);
+        if (recordCountProperty instanceof Number) {
+            recordCount = ((Number) recordCountProperty).longValue();
+        }
+    }
+
+    /**
+     *
+     * @param bucket
+     *            the bucket we are using.
+     * @param blobName
+     *            the blob name.
+     * @return a new instance of OffsetManagerKey
+     */
+    public static OffsetManager.OffsetManagerKey asKey(final String bucket, final String blobName) {
+        return () -> Map.of(CONTAINER, bucket, BLOB_NAME, blobName);
+    }
+
+    /**
+     * Creates an AzureOffsetManagerEntry. Will return {@code null} if properties is {@code null}.
+     *
+     * @param properties
+     *            the properties to wrap. May be {@code null}.
+     * @return an AzureOffsetManagerEntry.
+     * @throws IllegalArgumentException
+     *             if one of the {@link #RESTRICTED_KEYS} is missing.
+     */
+    @Override
+    public AzureOffsetManagerEntry fromProperties(final Map<String, Object> properties) {
+        if (properties == null) {
+            return null;
+        }
+        return new AzureOffsetManagerEntry(container, blobName, properties);
+    }
+
+    @Override
+    public Object getProperty(final String key) {
+        if (RECORD_COUNT.equals(key)) {
+            return recordCount;
+        }
+        return data.get(key);
+    }
+
+    @Override
+    public void setProperty(final String property, final Object value) {
+        if (RESTRICTED_KEYS.contains(property)) {
+            throw new IllegalArgumentException(
+                    String.format("'%s' is a restricted key and may not be set using setProperty()", property));
+        }
+        data.put(property, value);
+    }
+
+    @Override
+    public void incrementRecordCount() {
+        recordCount++;
+    }
+
+    /**
+     * Gets the umber of records extracted from data returned from Azure Blob.
+     *
+     * @return the umber of records extracted from data returned from Azure Blob.
+     */
+    public long getRecordCount() {
+        return recordCount;
+    }
+
+    /**
+     * Gets the blob name for the current object.
+     *
+     * @return the blob name.
+     */
+    public String getKey() {
+        return blobName;
+    }
+
+    /**
+     * Gets the Azure container for the current object.
+     *
+     * @return the Azure container for the current object.
+     */
+    public String getContainer() {
+        return container;
+    }
+    /**
+     * Creates a new offset map. No defensive copy is necessary.
+     *
+     * @return a new map of properties and values.
+     */
+    @Override
+    public Map<String, Object> getProperties() {
+        final Map<String, Object> result = new HashMap<>(data);
+        result.put(RECORD_COUNT, recordCount);
+        return result;
+    }
+    /**
+     * Returns the OffsetManagerKey for this Entry.
+     *
+     * @return the OffsetManagerKey for this Entry.
+     */
+    @Override
+    public OffsetManager.OffsetManagerKey getManagerKey() {
+        return () -> Map.of(CONTAINER, container, BLOB_NAME, blobName);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (other instanceof AzureOffsetManagerEntry) {
+            return compareTo((AzureOffsetManagerEntry) other) == 0;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(container, blobName);
+    }
+
+    @Override
+    public int compareTo(final AzureOffsetManagerEntry other) {
+        if (this == other) { // NOPMD comparing instance
+            return 0;
+        }
+        int result = ((String) getProperty(CONTAINER)).compareTo((String) other.getProperty(CONTAINER));
+        if (result == 0) {
+            result = getKey().compareTo(other.getKey());
+            if (result == 0) {
+                result = Long.compare(getRecordCount(), other.getRecordCount());
+            }
+        }
+        return result;
+    }
+}

--- a/azure-source-connector/src/test/java/io/aiven/kafka/connect/azure/source/utils/AzureOffsetManagerEntryTest.java
+++ b/azure-source-connector/src/test/java/io/aiven/kafka/connect/azure/source/utils/AzureOffsetManagerEntryTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.azure.source.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+
+import io.aiven.kafka.connect.common.source.OffsetManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class AzureOffsetManagerEntryTest {
+
+    static final String TEST_CONTAINER = "test-container";
+
+    static final String BLOB_NAME = "blob_1";
+
+    private SourceTaskContext sourceTaskContext;
+
+    private OffsetManager<AzureOffsetManagerEntry> offsetManager;
+
+    private OffsetStorageReader offsetStorageReader;
+
+    @BeforeEach
+    public void setUp() {
+        offsetStorageReader = mock(OffsetStorageReader.class);
+        sourceTaskContext = mock(SourceTaskContext.class);
+        when(sourceTaskContext.offsetStorageReader()).thenReturn(offsetStorageReader);
+        offsetManager = new OffsetManager<>(sourceTaskContext);
+    }
+
+    private Map<String, Object> createPartitionMap() {
+        final Map<String, Object> partitionKey = new HashMap<>();
+        partitionKey.put(AzureOffsetManagerEntry.CONTAINER, TEST_CONTAINER);
+        partitionKey.put(AzureOffsetManagerEntry.BLOB_NAME, BLOB_NAME);
+        return partitionKey;
+    }
+
+    public static AzureOffsetManagerEntry newEntry() {
+        return new AzureOffsetManagerEntry(TEST_CONTAINER, BLOB_NAME);
+    }
+
+    @Test
+    void testGetEntry() {
+        final Map<String, Object> storedData = new HashMap<>();
+        storedData.putAll(createPartitionMap());
+        storedData.put("random_entry", 5L);
+
+        when(offsetStorageReader.offset(any())).thenReturn(storedData);
+
+        final AzureOffsetManagerEntry keyEntry = newEntry();
+        final Optional<AzureOffsetManagerEntry> entry = offsetManager.getEntry(keyEntry.getManagerKey(),
+                keyEntry::fromProperties);
+        assertThat(entry).isPresent();
+        assertThat(entry.get().getContainer()).isEqualTo(TEST_CONTAINER);
+        assertThat(entry.get().getProperty("random_entry")).isEqualTo(5L);
+        verify(sourceTaskContext, times(1)).offsetStorageReader();
+
+        // verify second read reads from local data
+
+        final Optional<AzureOffsetManagerEntry> entry2 = offsetManager.getEntry(entry.get().getManagerKey(),
+                entry.get()::fromProperties);
+        assertThat(entry2).isPresent();
+        assertThat(entry2.get().getContainer()).isEqualTo(TEST_CONTAINER);
+        assertThat(entry2.get().getProperty("random_entry")).isEqualTo(5L);
+        verify(sourceTaskContext, times(1)).offsetStorageReader();
+    }
+
+    @Test
+    void testFromProperties() {
+        final AzureOffsetManagerEntry entry = new AzureOffsetManagerEntry(TEST_CONTAINER, BLOB_NAME);
+        assertThat(entry.getRecordCount()).isEqualTo(0L);
+        assertThat(entry.getProperty("random_entry")).isNull();
+
+        entry.setProperty("random_entry", 5L);
+        entry.incrementRecordCount();
+        assertThat(entry.getRecordCount()).isEqualTo(1L);
+        assertThat(entry.getProperty("random_entry")).isEqualTo(5L);
+
+        final AzureOffsetManagerEntry other = entry.fromProperties(entry.getProperties());
+        assertThat(other.getRecordCount()).isEqualTo(1L);
+        assertThat(other.getProperty("random_entry")).isEqualTo(5L);
+
+    }
+}


### PR DESCRIPTION
This is the offset manager entry for the Azure blob source. It is similar to the S3 source offset manager entry as the bucket is analogous to the container and blob is analogous to the S3Object. 

However it is worth noting they are slightly different.