### PR TITLE
Aindriu aiven/add source record iterator

### DIFF
--- a/azure-source-connector/build.gradle.kts
+++ b/azure-source-connector/build.gradle.kts
@@ -53,8 +53,10 @@ idea {
 dependencies {
   compileOnly(apache.kafka.connect.api)
 
+  implementation("commons-io:commons-io:2.18.0")
+  implementation("org.apache.commons:commons-lang3:3.17.0")
   implementation(project(":commons"))
-
+  implementation(apache.commons.collection4)
   implementation("com.azure:azure-storage-blob:12.29.0")
 
   implementation(tools.spotbugs.annotations)

--- a/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/AzureBlobClient.java
+++ b/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/AzureBlobClient.java
@@ -17,6 +17,7 @@
 package io.aiven.kafka.connect.azure.source.utils;
 
 import java.nio.ByteBuffer;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import io.aiven.kafka.connect.azure.source.config.AzureBlobSourceConfig;
@@ -35,6 +36,7 @@ public class AzureBlobClient {
 
     private final AzureBlobSourceConfig config;
     private final BlobContainerAsyncClient containerAsyncClient;
+    private final Predicate<BlobItem> filterPredicate = blobItem -> blobItem.getProperties().getContentLength() > 0;
 
     /**
      *
@@ -58,7 +60,7 @@ public class AzureBlobClient {
         final ListBlobsOptions options = new ListBlobsOptions();
         options.setPrefix(config.getAzurePrefix());
         options.setMaxResultsPerPage(config.getAzureFetchPageSize());
-        return containerAsyncClient.listBlobs(options).toStream();
+        return containerAsyncClient.listBlobs(options).toStream().filter(filterPredicate);
     }
 
     /**

--- a/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/AzureBlobSourceRecord.java
+++ b/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/AzureBlobSourceRecord.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.azure.source.utils;
+
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.aiven.kafka.connect.common.config.enums.ErrorsTolerance;
+import io.aiven.kafka.connect.common.source.OffsetManager;
+import io.aiven.kafka.connect.common.source.task.Context;
+
+import com.azure.storage.blob.models.BlobItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AzureBlobSourceRecord {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureBlobSourceRecord.class);
+    private SchemaAndValue keyData;
+    private SchemaAndValue valueData;
+    /** The AzureOffsetManagerEntry for this source record */
+    private AzureOffsetManagerEntry offsetManagerEntry;
+    private Context<String> context;
+    private final BlobItem blobItem;
+
+    public AzureBlobSourceRecord(final BlobItem blobItem) {
+        this.blobItem = blobItem;
+    }
+
+    public AzureBlobSourceRecord(final AzureBlobSourceRecord azureBlobSourceRecord) {
+        this(azureBlobSourceRecord.blobItem);
+        this.offsetManagerEntry = azureBlobSourceRecord.offsetManagerEntry
+                .fromProperties(azureBlobSourceRecord.getOffsetManagerEntry().getProperties());
+        this.keyData = azureBlobSourceRecord.keyData;
+        this.valueData = azureBlobSourceRecord.valueData;
+        this.context = azureBlobSourceRecord.context;
+    }
+
+    public void setOffsetManagerEntry(final AzureOffsetManagerEntry offsetManagerEntry) {
+        this.offsetManagerEntry = offsetManagerEntry.fromProperties(offsetManagerEntry.getProperties());
+    }
+
+    public long getRecordCount() {
+        return offsetManagerEntry == null ? 0 : offsetManagerEntry.getRecordCount();
+    }
+
+    public void setKeyData(final SchemaAndValue keyData) {
+        this.keyData = keyData;
+    }
+
+    public void incrementRecordCount() {
+        this.offsetManagerEntry.incrementRecordCount();
+    }
+
+    public void setValueData(final SchemaAndValue valueData) {
+        this.valueData = valueData;
+    }
+
+    public String getTopic() {
+        return context.getTopic().orElse(null);
+    }
+
+    public Integer getPartition() {
+        return context.getPartition().orElse(null);
+    }
+
+    public String getBlobName() {
+        return blobItem.getName();
+    }
+
+    public SchemaAndValue getKey() {
+        return new SchemaAndValue(keyData.schema(), keyData.value());
+    }
+
+    public SchemaAndValue getValue() {
+        return new SchemaAndValue(valueData.schema(), valueData.value());
+    }
+
+    public AzureOffsetManagerEntry getOffsetManagerEntry() {
+        return offsetManagerEntry.fromProperties(offsetManagerEntry.getProperties()); // return a defensive copy
+    }
+
+    public long getAzureBlobSize() {
+        return blobItem.getProperties().getContentLength();
+    }
+
+    public Context<String> getContext() {
+        return new Context<>(context) {
+        };
+
+    }
+    public void setContext(final Context<String> context) {
+        this.context = new Context<>(context) {
+        };
+    }
+
+    /**
+     * Creates a SourceRecord that can be returned to a Kafka topic
+     *
+     * @return A kafka {@link SourceRecord SourceRecord} This can return null if error tolerance is set to 'All'
+     */
+    public SourceRecord getSourceRecord(final ErrorsTolerance tolerance,
+            final OffsetManager<AzureOffsetManagerEntry> offsetManager) {
+        try {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Source Record: {} for Topic: {} , Partition: {}, recordCount: {}", getBlobName(),
+                        getTopic(), getPartition(), getRecordCount());
+            }
+            offsetManager.addEntry(offsetManagerEntry);
+            return new SourceRecord(offsetManagerEntry.getManagerKey().getPartitionMap(),
+                    offsetManagerEntry.getProperties(), getTopic(), getPartition(), keyData.schema(), keyData.value(),
+                    valueData.schema(), valueData.value());
+        } catch (DataException e) {
+            if (ErrorsTolerance.NONE.equals(tolerance)) {
+                throw new ConnectException("Data Exception caught during S3 record to source record transformation", e);
+            } else {
+                LOGGER.warn(
+                        "Data Exception caught during S3 record to source record transformation {} . errors.tolerance set to 'all', logging warning and continuing to process.",
+                        e.getMessage(), e);
+                return null;
+            }
+        }
+    }
+
+}

--- a/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/AzureOffsetManagerEntry.java
+++ b/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/AzureOffsetManagerEntry.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2025 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.azure.source.utils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import io.aiven.kafka.connect.common.source.OffsetManager;
+
+public final class AzureOffsetManagerEntry implements OffsetManager.OffsetManagerEntry<AzureOffsetManagerEntry> {
+
+    public static final String CONTAINER = "container";
+    public static final String BLOB_NAME = "blobName";
+    public static final String RECORD_COUNT = "recordCount";
+
+    /**
+     * THe list of Keys that may not be set via {@link #setProperty(String, Object)}.
+     */
+    static final List<String> RESTRICTED_KEYS = List.of(RECORD_COUNT);
+    /** The data map that stores all the values */
+    private final Map<String, Object> data;
+    /** THe record count for the data map. Extracted here because it is used/updated frequently during processing */
+    private long recordCount;
+
+    private final String container;
+    private final String blobName;
+
+    /**
+     * Construct the AzureOffsetManagerEntry.
+     *
+     * @param container
+     *            the bucket we are using.
+     * @param blobName
+     *            the blob name.
+     */
+    public AzureOffsetManagerEntry(final String container, final String blobName) {
+        this.container = container;
+        this.blobName = blobName;
+        data = new HashMap<>();
+    }
+
+    /**
+     * Constructs an OffsetManagerEntry from an existing map. Used to reconstitute previously serialized
+     * AzureOffsetManagerEntries. used by {@link #fromProperties(Map)}
+     *
+     * @param properties
+     *            the property map.
+     */
+    private AzureOffsetManagerEntry(final String container, final String blobName,
+            final Map<String, Object> properties) {
+        this(container, blobName);
+        data.putAll(properties);
+        final Object recordCountProperty = data.computeIfAbsent(RECORD_COUNT, s -> 0L);
+        if (recordCountProperty instanceof Number) {
+            recordCount = ((Number) recordCountProperty).longValue();
+        }
+    }
+
+    /**
+     *
+     * @param bucket
+     *            the bucket we are using.
+     * @param blobName
+     *            the blob name.
+     * @return a new instance of OffsetManagerKey
+     */
+    public static OffsetManager.OffsetManagerKey asKey(final String bucket, final String blobName) {
+        return () -> Map.of(CONTAINER, bucket, BLOB_NAME, blobName);
+    }
+
+    /**
+     * Creates an AzureOffsetManagerEntry. Will return {@code null} if properties is {@code null}.
+     *
+     * @param properties
+     *            the properties to wrap. May be {@code null}.
+     * @return an AzureOffsetManagerEntry.
+     * @throws IllegalArgumentException
+     *             if one of the {@link #RESTRICTED_KEYS} is missing.
+     */
+    @Override
+    public AzureOffsetManagerEntry fromProperties(final Map<String, Object> properties) {
+        if (properties == null) {
+            return null;
+        }
+        return new AzureOffsetManagerEntry(container, blobName, properties);
+    }
+
+    @Override
+    public Object getProperty(final String key) {
+        if (RECORD_COUNT.equals(key)) {
+            return recordCount;
+        }
+        return data.get(key);
+    }
+
+    @Override
+    public void setProperty(final String property, final Object value) {
+        if (RESTRICTED_KEYS.contains(property)) {
+            throw new IllegalArgumentException(
+                    String.format("'%s' is a restricted key and may not be set using setProperty()", property));
+        }
+        data.put(property, value);
+    }
+
+    @Override
+    public void incrementRecordCount() {
+        recordCount++;
+    }
+
+    /**
+     * Gets the umber of records extracted from data returned from Azure Blob.
+     *
+     * @return the umber of records extracted from data returned from Azure Blob.
+     */
+    public long getRecordCount() {
+        return recordCount;
+    }
+
+    /**
+     * Gets the blob name for the current object.
+     *
+     * @return the blob name.
+     */
+    public String getKey() {
+        return blobName;
+    }
+
+    /**
+     * Gets the Azure container for the current object.
+     *
+     * @return the Azure container for the current object.
+     */
+    public String getContainer() {
+        return container;
+    }
+    /**
+     * Creates a new offset map. No defensive copy is necessary.
+     *
+     * @return a new map of properties and values.
+     */
+    @Override
+    public Map<String, Object> getProperties() {
+        final Map<String, Object> result = new HashMap<>(data);
+        result.put(RECORD_COUNT, recordCount);
+        return result;
+    }
+    /**
+     * Returns the OffsetManagerKey for this Entry.
+     *
+     * @return the OffsetManagerKey for this Entry.
+     */
+    @Override
+    public OffsetManager.OffsetManagerKey getManagerKey() {
+        return () -> Map.of(CONTAINER, container, BLOB_NAME, blobName);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (other instanceof AzureOffsetManagerEntry) {
+            return compareTo((AzureOffsetManagerEntry) other) == 0;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(container, blobName);
+    }
+
+    @Override
+    public int compareTo(final AzureOffsetManagerEntry other) {
+        if (this == other) { // NOPMD comparing instance
+            return 0;
+        }
+        int result = ((String) getProperty(CONTAINER)).compareTo((String) other.getProperty(CONTAINER));
+        if (result == 0) {
+            result = getKey().compareTo(other.getKey());
+            if (result == 0) {
+                result = Long.compare(getRecordCount(), other.getRecordCount());
+            }
+        }
+        return result;
+    }
+}

--- a/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/SourceRecordIterator.java
+++ b/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/SourceRecordIterator.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.azure.source.utils;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.utils.ByteBufferInputStream;
+import org.apache.kafka.connect.data.SchemaAndValue;
+
+import io.aiven.kafka.connect.azure.source.config.AzureBlobSourceConfig;
+import io.aiven.kafka.connect.common.source.OffsetManager;
+import io.aiven.kafka.connect.common.source.input.Transformer;
+import io.aiven.kafka.connect.common.source.input.utils.FilePatternUtils;
+import io.aiven.kafka.connect.common.source.task.Context;
+import io.aiven.kafka.connect.common.source.task.DistributionStrategy;
+import io.aiven.kafka.connect.common.source.task.DistributionType;
+
+import com.azure.storage.blob.models.BlobItem;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Iterator that processes Azure Blob files and creates Kafka source records. Supports different output formats (Avro,
+ * JSON, Parquet).
+ */
+public final class SourceRecordIterator implements Iterator<AzureBlobSourceRecord> {
+    /** The OffsetManager that we are using */
+    private final OffsetManager<AzureOffsetManagerEntry> offsetManager;
+
+    /** The configuration for this Azure blob source */
+    private final AzureBlobSourceConfig azureBlobSourceConfig;
+    /** The transformer for the data conversions */
+    private final Transformer transformer;
+    /** The azure blob client that provides the blobItems */
+    private final AzureBlobClient azureBlobClient;
+    /** the taskId of this running task */
+    private int taskId;
+
+    /** The Azure container we are processing */
+    private final String container;
+
+    /**
+     * The inner iterator to provides a base AzureBlobSourceRecord for an Blob that has passed the filters and
+     * potentially had data extracted.
+     */
+    private Iterator<AzureBlobSourceRecord> inner;
+    /**
+     * The outer iterator that provides an AzureBlobSourceRecord for each record contained by the Blob identified by the
+     * inner record.
+     */
+    private Iterator<AzureBlobSourceRecord> outer;
+    /** The topic(s) which have been configured with the 'topics' configuration */
+    private final Optional<String> targetTopics;
+
+    /** Check if the blob name is part of the 'target' files configured to be extracted from Azure */
+    final FileMatching fileMatching;
+    /** The predicate which will determine if an Azure Blob should be assigned to this task for processing */
+    final Predicate<Optional<AzureBlobSourceRecord>> taskAssignment;
+    /** The utility to extract the context from the Blob name */
+    private FilePatternUtils filePattern;
+    /**
+     * The blob which is currently being processed, when rehydrating from Azure we will skip other blob items until
+     * after this item
+     */
+    private String lastSeenBlobName;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SourceRecordIterator.class);
+
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "stores mutable fields in offset manager to be reviewed before release")
+    public SourceRecordIterator(final AzureBlobSourceConfig azureBlobSourceConfig,
+            final OffsetManager<AzureOffsetManagerEntry> offsetManager, final Transformer transformer,
+            final AzureBlobClient azureBlobClient) {
+
+        super();
+        this.azureBlobSourceConfig = azureBlobSourceConfig;
+        this.offsetManager = offsetManager;
+        this.container = azureBlobSourceConfig.getAzureContainerName();
+        this.transformer = transformer;
+        this.azureBlobClient = azureBlobClient;
+        this.targetTopics = Optional.ofNullable(azureBlobSourceConfig.getTargetTopic());
+        this.taskAssignment = new TaskAssignment(initializeDistributionStrategy());
+        this.taskId = azureBlobSourceConfig.getTaskId();
+        this.fileMatching = new FileMatching(filePattern);
+
+        inner = getAzureBlobSourceRecordStream(azureBlobClient).iterator();
+        outer = Collections.emptyIterator();
+    }
+
+    private Stream<AzureBlobSourceRecord> getAzureBlobSourceRecordStream(final AzureBlobClient client) {
+        return client.getAzureBlobStream().map(fileMatching).filter(taskAssignment).map(Optional::get);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (!outer.hasNext()) {
+            // Remove the last seen Blob from the offsets as the file has been completely processed.
+            offsetManager.removeEntry(
+                    AzureOffsetManagerEntry.asKey(container, StringUtils.defaultIfBlank(lastSeenBlobName, "")));
+        }
+        if (!inner.hasNext() && !outer.hasNext()) {
+            inner = getAzureBlobSourceRecordStream(azureBlobClient).iterator();
+        }
+        while (!outer.hasNext() && inner.hasNext()) {
+            outer = convert(inner.next()).iterator();
+        }
+        return outer.hasNext();
+    }
+
+    @Override
+    public AzureBlobSourceRecord next() {
+        return outer.next();
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("This iterator is unmodifiable");
+    }
+
+    /**
+     * Converts the Blob Item into stream of AzureBlobSourceRecords.
+     *
+     * @param azureBlobSourceRecord
+     *            the SourceRecord that drives the creation of source records with values.
+     * @return a stream of AzureBlobSourceRecords created from the input stream of the Blob.
+     */
+    private Stream<AzureBlobSourceRecord> convert(final AzureBlobSourceRecord azureBlobSourceRecord) {
+        azureBlobSourceRecord.setKeyData(transformer.getKeyData(azureBlobSourceRecord.getBlobName(),
+                azureBlobSourceRecord.getTopic(), azureBlobSourceConfig));
+
+        lastSeenBlobName = azureBlobSourceRecord.getBlobName();
+
+        return transformer
+                .getRecords(
+                        () -> new ByteBufferInputStream(
+                                azureBlobClient.getBlob(azureBlobSourceRecord.getBlobName()).blockFirst()),
+                        azureBlobSourceRecord.getAzureBlobSize(), azureBlobSourceRecord.getContext(),
+                        azureBlobSourceConfig, azureBlobSourceRecord.getRecordCount())
+                .map(new Mapper(azureBlobSourceRecord));
+
+    }
+
+    private DistributionStrategy initializeDistributionStrategy() {
+        final DistributionType distributionType = azureBlobSourceConfig.getDistributionType();
+        final int maxTasks = azureBlobSourceConfig.getMaxTasks();
+        this.taskId = azureBlobSourceConfig.getTaskId() % maxTasks;
+        this.filePattern = new FilePatternUtils(
+                azureBlobSourceConfig.getAzureBlobFileNameFragment().getFilenameTemplate().toString());
+        return distributionType.getDistributionStrategy(maxTasks);
+    }
+
+    /**
+     * maps the data from the @{link Transformer} stream to an AzureBlobSourceRecord given all the additional data
+     * required.
+     */
+    static class Mapper implements Function<SchemaAndValue, AzureBlobSourceRecord> {
+        /**
+         * The AzureBlobSourceRecord that produceces the values.
+         */
+        private final AzureBlobSourceRecord sourceRecord;
+
+        public Mapper(final AzureBlobSourceRecord sourceRecord) {
+            // operation within the Transformer
+            // to see if there are more records.
+            this.sourceRecord = sourceRecord;
+        }
+
+        @Override
+        public AzureBlobSourceRecord apply(final SchemaAndValue valueData) {
+            sourceRecord.incrementRecordCount();
+            final AzureBlobSourceRecord result = new AzureBlobSourceRecord(sourceRecord);
+            result.setValueData(valueData);
+            return result;
+        }
+    }
+
+    class TaskAssignment implements Predicate<Optional<AzureBlobSourceRecord>> {
+        final DistributionStrategy distributionStrategy;
+
+        TaskAssignment(final DistributionStrategy distributionStrategy) {
+            this.distributionStrategy = distributionStrategy;
+        }
+
+        @Override
+        public boolean test(final Optional<AzureBlobSourceRecord> azureBlobSourceRecord) {
+            if (azureBlobSourceRecord.isPresent()) {
+                final AzureBlobSourceRecord record = azureBlobSourceRecord.get();
+                final Context<String> context = record.getContext();
+                return taskId == distributionStrategy.getTaskFor(context);
+
+            }
+            return false;
+        }
+
+    }
+
+    class FileMatching implements Function<BlobItem, Optional<AzureBlobSourceRecord>> {
+
+        final FilePatternUtils utils;
+        FileMatching(final FilePatternUtils utils) {
+            this.utils = utils;
+        }
+
+        @Override
+        public Optional<AzureBlobSourceRecord> apply(final BlobItem blobItem) {
+
+            final Optional<Context<String>> optionalContext = utils.process(blobItem.getName());
+            if (optionalContext.isPresent()) {
+                final AzureBlobSourceRecord azureBlobSourceRecord = new AzureBlobSourceRecord(blobItem);
+                final Context<String> context = optionalContext.get();
+                overrideContextTopic(context);
+                azureBlobSourceRecord.setContext(context);
+                AzureOffsetManagerEntry offsetManagerEntry = new AzureOffsetManagerEntry(container, blobItem.getName());
+                offsetManagerEntry = offsetManager
+                        .getEntry(offsetManagerEntry.getManagerKey(), offsetManagerEntry::fromProperties)
+                        .orElse(offsetManagerEntry);
+                azureBlobSourceRecord.setOffsetManagerEntry(offsetManagerEntry);
+                return Optional.of(azureBlobSourceRecord);
+            }
+            return Optional.empty();
+        }
+
+        private void overrideContextTopic(final Context<String> context) {
+            // Set the target topic in the context if it has been set from configuration.
+            if (targetTopics.isPresent()) {
+                if (context.getTopic().isPresent()) {
+                    LOGGER.debug(
+                            "Overriding topic '{}' extracted from Blob name with topic '{}' from configuration 'topics'. ",
+                            context.getTopic().get(), targetTopics.get());
+                }
+                context.setTopic(targetTopics.get());
+            }
+        }
+    }
+
+}

--- a/azure-source-connector/src/test/java/io/aiven/kafka/connect/azure/source/utils/AzureBlobClientTest.java
+++ b/azure-source-connector/src/test/java/io/aiven/kafka/connect/azure/source/utils/AzureBlobClientTest.java
@@ -37,6 +37,7 @@ import com.azure.storage.blob.BlobAsyncClient;
 import com.azure.storage.blob.BlobContainerAsyncClient;
 import com.azure.storage.blob.BlobServiceAsyncClient;
 import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.models.BlobItemProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
@@ -113,9 +114,11 @@ class AzureBlobClientTest {
 
     private static Stream<BlobItem> createListOfBlobs(final int numberOfItems) {
         final List<BlobItem> items = new ArrayList<>();
+        final BlobItemProperties props = new BlobItemProperties().setContentLength(10_000L);
         for (int i = 0; i < numberOfItems; i++) {
             final BlobItem item = new BlobItem();// NOPMD avoid creating new instances in a loop
             item.setName(String.valueOf(i));
+            item.setProperties(props);
             items.add(item);
         }
         return items.stream();

--- a/azure-source-connector/src/test/java/io/aiven/kafka/connect/azure/source/utils/AzureOffsetManagerEntryTest.java
+++ b/azure-source-connector/src/test/java/io/aiven/kafka/connect/azure/source/utils/AzureOffsetManagerEntryTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.azure.source.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+
+import io.aiven.kafka.connect.common.source.OffsetManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class AzureOffsetManagerEntryTest {
+
+    static final String TEST_CONTAINER = "test-container";
+
+    static final String BLOB_NAME = "blob_1";
+
+    private SourceTaskContext sourceTaskContext;
+
+    private OffsetManager<AzureOffsetManagerEntry> offsetManager;
+
+    private OffsetStorageReader offsetStorageReader;
+
+    @BeforeEach
+    public void setUp() {
+        offsetStorageReader = mock(OffsetStorageReader.class);
+        sourceTaskContext = mock(SourceTaskContext.class);
+        when(sourceTaskContext.offsetStorageReader()).thenReturn(offsetStorageReader);
+        offsetManager = new OffsetManager<>(sourceTaskContext);
+    }
+
+    private Map<String, Object> createPartitionMap() {
+        final Map<String, Object> partitionKey = new HashMap<>();
+        partitionKey.put(AzureOffsetManagerEntry.CONTAINER, TEST_CONTAINER);
+        partitionKey.put(AzureOffsetManagerEntry.BLOB_NAME, BLOB_NAME);
+        return partitionKey;
+    }
+
+    public static AzureOffsetManagerEntry newEntry() {
+        return new AzureOffsetManagerEntry(TEST_CONTAINER, BLOB_NAME);
+    }
+
+    @Test
+    void testGetEntry() {
+        final Map<String, Object> storedData = new HashMap<>();
+        storedData.putAll(createPartitionMap());
+        storedData.put("random_entry", 5L);
+
+        when(offsetStorageReader.offset(any())).thenReturn(storedData);
+
+        final AzureOffsetManagerEntry keyEntry = newEntry();
+        final Optional<AzureOffsetManagerEntry> entry = offsetManager.getEntry(keyEntry.getManagerKey(),
+                keyEntry::fromProperties);
+        assertThat(entry).isPresent();
+        assertThat(entry.get().getContainer()).isEqualTo(TEST_CONTAINER);
+        assertThat(entry.get().getProperty("random_entry")).isEqualTo(5L);
+        verify(sourceTaskContext, times(1)).offsetStorageReader();
+
+        // verify second read reads from local data
+
+        final Optional<AzureOffsetManagerEntry> entry2 = offsetManager.getEntry(entry.get().getManagerKey(),
+                entry.get()::fromProperties);
+        assertThat(entry2).isPresent();
+        assertThat(entry2.get().getContainer()).isEqualTo(TEST_CONTAINER);
+        assertThat(entry2.get().getProperty("random_entry")).isEqualTo(5L);
+        verify(sourceTaskContext, times(1)).offsetStorageReader();
+    }
+
+    @Test
+    void testFromProperties() {
+        final AzureOffsetManagerEntry entry = new AzureOffsetManagerEntry(TEST_CONTAINER, BLOB_NAME);
+        assertThat(entry.getRecordCount()).isEqualTo(0L);
+        assertThat(entry.getProperty("random_entry")).isNull();
+
+        entry.setProperty("random_entry", 5L);
+        entry.incrementRecordCount();
+        assertThat(entry.getRecordCount()).isEqualTo(1L);
+        assertThat(entry.getProperty("random_entry")).isEqualTo(5L);
+
+        final AzureOffsetManagerEntry other = entry.fromProperties(entry.getProperties());
+        assertThat(other.getRecordCount()).isEqualTo(1L);
+        assertThat(other.getProperty("random_entry")).isEqualTo(5L);
+
+    }
+}

--- a/azure-source-connector/src/test/java/io/aiven/kafka/connect/azure/source/utils/AzureSourceRecordTest.java
+++ b/azure-source-connector/src/test/java/io/aiven/kafka/connect/azure/source/utils/AzureSourceRecordTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.azure.source.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.aiven.kafka.connect.azure.source.config.AzureBlobSourceConfig;
+import io.aiven.kafka.connect.common.config.enums.ErrorsTolerance;
+import io.aiven.kafka.connect.common.source.OffsetManager;
+import io.aiven.kafka.connect.common.source.task.Context;
+
+import com.azure.storage.blob.models.BlobItem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AzureBlobSourceRecordTest {
+
+    public static final String TEST_BLOB_NAME_TXT = "test-blob-name.txt";
+    public static final String CONTAINER = "container";
+    @Mock
+    private AzureBlobSourceConfig azureBlobSourceConfig;
+
+    @Mock
+    private OffsetManager<AzureOffsetManagerEntry> offsetManager;
+
+    private Context<String> context;
+
+    @Mock
+    private BlobItem blobItem;
+
+    @Test
+    void testCreateSourceRecord() {
+        final String topic = "test-topic";
+        final AzureOffsetManagerEntry entry = new AzureOffsetManagerEntry(CONTAINER, TEST_BLOB_NAME_TXT);
+        context = new Context<>(TEST_BLOB_NAME_TXT);
+        context.setPartition(null);
+        context.setTopic(topic);
+        final AzureBlobSourceRecord azureBlobSourceRecord = new AzureBlobSourceRecord(blobItem);
+        azureBlobSourceRecord.setOffsetManagerEntry(entry);
+        azureBlobSourceRecord.setContext(context);
+        azureBlobSourceRecord.setValueData(new SchemaAndValue(null, ""));
+        azureBlobSourceRecord.setKeyData(new SchemaAndValue(null, ""));
+
+        final SourceRecord result = azureBlobSourceRecord.getSourceRecord(ErrorsTolerance.NONE, offsetManager);
+
+        assertThat(result.topic()).isEqualTo(topic);
+        assertThat(result.kafkaPartition()).isEqualTo(null);
+
+    }
+
+    @Test
+    void testCreateSourceRecordWithDataError() {
+        context = mock(Context.class);
+        final AzureOffsetManagerEntry offsetManagerEntry = mock(AzureOffsetManagerEntry.class);
+        when(offsetManagerEntry.getManagerKey()).thenThrow(new DataException("Test Exception"));
+        when(offsetManagerEntry.fromProperties(any())).thenReturn(offsetManagerEntry);
+        final AzureBlobSourceRecord azureBlobSourceRecord = new AzureBlobSourceRecord(blobItem);
+        azureBlobSourceRecord.setOffsetManagerEntry(offsetManagerEntry);
+        azureBlobSourceRecord.setContext(context);
+
+        assertThatExceptionOfType(ConnectException.class).as("Errors tolerance: NONE")
+                .isThrownBy(() -> azureBlobSourceRecord.getSourceRecord(ErrorsTolerance.NONE, offsetManager));
+        final SourceRecord result = azureBlobSourceRecord.getSourceRecord(ErrorsTolerance.ALL, offsetManager);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void testModifyingInitialContextDoesNotAlterTheSourceRecordsContext() {
+        final String topic = "test-topic";
+        final AzureOffsetManagerEntry entry = new AzureOffsetManagerEntry(CONTAINER, TEST_BLOB_NAME_TXT);
+        context = new Context<>(TEST_BLOB_NAME_TXT);
+        context.setPartition(null);
+        context.setTopic(topic);
+        final AzureBlobSourceRecord azureBlobSourceRecord = new AzureBlobSourceRecord(blobItem);
+        azureBlobSourceRecord.setOffsetManagerEntry(entry);
+        azureBlobSourceRecord.setContext(context);
+        azureBlobSourceRecord.setValueData(new SchemaAndValue(null, ""));
+        azureBlobSourceRecord.setKeyData(new SchemaAndValue(null, ""));
+
+        // alter context and it should have no impact on the source record.
+        context.setPartition(14);
+        context.setTopic("a-diff-topic");
+        SourceRecord result = azureBlobSourceRecord.getSourceRecord(ErrorsTolerance.NONE, offsetManager);
+        assertThat(result.topic()).isEqualTo(topic);
+        assertThat(result.kafkaPartition()).isEqualTo(null);
+
+        // We should return a defensive copy so altering here should not affect the ssSourceRecord
+        context = azureBlobSourceRecord.getContext();
+        context.setPartition(99);
+        context.setTopic("another-diff-topic");
+        result = azureBlobSourceRecord.getSourceRecord(ErrorsTolerance.NONE, offsetManager);
+        assertThat(result.topic()).isEqualTo(topic);
+        assertThat(result.kafkaPartition()).isEqualTo(null);
+
+    }
+
+    @Test
+    void testModifyingInitialOffsetManagerEntryDoesNotAlterTheSourceRecordsOffsetManagerEntry() {
+        final String topic = "test-topic";
+        AzureOffsetManagerEntry entry = new AzureOffsetManagerEntry(CONTAINER, TEST_BLOB_NAME_TXT);
+        context = new Context<>(TEST_BLOB_NAME_TXT);
+        context.setPartition(null);
+        context.setTopic(topic);
+        final AzureBlobSourceRecord azureSourceRecord = new AzureBlobSourceRecord(blobItem);
+        azureSourceRecord.setOffsetManagerEntry(entry);
+        azureSourceRecord.setContext(context);
+        azureSourceRecord.setValueData(new SchemaAndValue(null, ""));
+        azureSourceRecord.setKeyData(new SchemaAndValue(null, ""));
+        final long currentRecordCount = entry.getRecordCount();
+        // alter entry record count and it should have no impact on the source record.
+        entry.incrementRecordCount();
+        assertThat(azureSourceRecord.getRecordCount()).isEqualTo(currentRecordCount);
+
+        // We should return a defensive copy so altering here should not affect the ssSourceRecord
+        entry = azureSourceRecord.getOffsetManagerEntry();
+        entry.incrementRecordCount();
+        entry.incrementRecordCount();
+        assertThat(azureSourceRecord.getRecordCount()).isEqualTo(currentRecordCount);
+
+    }
+
+}


### PR DESCRIPTION
* Adds the source record iterator, transformers the blob into source records that are ready to be delivered to Kafka
* Adds the AzureBlobSourceRecord which transforms the Azure information to a source record.
* Update to Azure Client to ignore any empty files.