### PR TITLE
Update configuration validation for Source connectors

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/FileNameFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/FileNameFragment.java
@@ -47,7 +47,6 @@ public final class FileNameFragment extends ConfigFragment {
     static final String DEFAULT_FILENAME_TEMPLATE = "{{topic}}-{{partition}}-{{start_offset}}";
 
     public static final String FILE_PATH_PREFIX_TEMPLATE_CONFIG = "file.prefix.template";
-    static final String DEFAULT_FILE_PATH_PREFIX_TEMPLATE = "topics/{{topic}}/partition={{partition}}/";
 
     public FileNameFragment(final AbstractConfig cfg) {
         super(cfg);

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
@@ -30,7 +30,6 @@ public class SourceCommonConfig extends CommonConfig {
 
     private final TransformerFragment transformerFragment;
     private final SourceConfigFragment sourceConfigFragment;
-    private final FileNameFragment fileNameFragment;
     private final OutputFormatFragment outputFormatFragment;
 
     public SourceCommonConfig(ConfigDef definition, Map<?, ?> originals) {// NOPMD
@@ -38,7 +37,6 @@ public class SourceCommonConfig extends CommonConfig {
         // Construct Fragments
         transformerFragment = new TransformerFragment(this);
         sourceConfigFragment = new SourceConfigFragment(this);
-        fileNameFragment = new FileNameFragment(this);
         outputFormatFragment = new OutputFormatFragment(this);
 
         validate(); // NOPMD ConstructorCallsOverridableMethod
@@ -47,7 +45,6 @@ public class SourceCommonConfig extends CommonConfig {
     private void validate() {
         transformerFragment.validate();
         sourceConfigFragment.validate();
-        fileNameFragment.validate();
         outputFormatFragment.validate();
     }
 
@@ -81,6 +78,10 @@ public class SourceCommonConfig extends CommonConfig {
 
     public int getTransformerMaxBufferSize() {
         return transformerFragment.getTransformerMaxBufferSize();
+    }
+
+    public String getSourcename() {
+        return sourceConfigFragment.getSourceName();
     }
 
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceConfigFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceConfigFragment.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.connect.common.config;
 
+import static io.aiven.kafka.connect.common.config.FileNameFragment.FILE_NAME_TEMPLATE_CONFIG;
 import static io.aiven.kafka.connect.common.source.task.DistributionType.OBJECT_HASH;
 
 import java.util.Arrays;
@@ -25,6 +26,7 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
 import io.aiven.kafka.connect.common.config.enums.ErrorsTolerance;
+import io.aiven.kafka.connect.common.config.validators.SourcenameTemplateValidator;
 import io.aiven.kafka.connect.common.source.task.DistributionType;
 
 import org.apache.commons.lang3.StringUtils;
@@ -49,22 +51,6 @@ public final class SourceConfigFragment extends ConfigFragment {
     }
 
     public static ConfigDef update(final ConfigDef configDef) {
-        int sourcePollingConfigCounter = 0;
-
-        configDef.define(MAX_POLL_RECORDS, ConfigDef.Type.INT, 500, ConfigDef.Range.atLeast(1),
-                ConfigDef.Importance.MEDIUM, "Max poll records", GROUP_OTHER, sourcePollingConfigCounter++,
-                ConfigDef.Width.NONE, MAX_POLL_RECORDS);
-        // KIP-298 Error Handling in Connect
-        configDef.define(ERRORS_TOLERANCE, ConfigDef.Type.STRING, ErrorsTolerance.NONE.name(),
-                new ErrorsToleranceValidator(), ConfigDef.Importance.MEDIUM,
-                "Indicates to the connector what level of exceptions are allowed before the connector stops, supported values : none,all",
-                GROUP_OTHER, sourcePollingConfigCounter++, ConfigDef.Width.NONE, ERRORS_TOLERANCE);
-
-        configDef.define(EXPECTED_MAX_MESSAGE_BYTES, ConfigDef.Type.INT, 1_048_588, ConfigDef.Importance.MEDIUM,
-                "The largest record batch size allowed by Kafka config max.message.bytes", GROUP_OTHER,
-                sourcePollingConfigCounter++, // NOPMD
-                // UnusedAssignment
-                ConfigDef.Width.NONE, EXPECTED_MAX_MESSAGE_BYTES);
 
         // Offset Storage config group includes target topics
         int offsetStorageGroupCounter = 0;
@@ -78,14 +64,47 @@ public final class SourceConfigFragment extends ConfigFragment {
                         + Arrays.stream(DistributionType.values())
                                 .map(DistributionType::value)
                                 .collect(Collectors.joining(", ")),
-                GROUP_OTHER, offsetStorageGroupCounter++, ConfigDef.Width.NONE, DISTRIBUTION_TYPE); // NOPMD
-                                                                                                    // UnusedAssignment
+                GROUP_OTHER, ++offsetStorageGroupCounter, ConfigDef.Width.NONE, DISTRIBUTION_TYPE);
+
+        int sourcePollingConfigCounter = 0;
+
+        configDef.define(MAX_POLL_RECORDS, ConfigDef.Type.INT, 500, ConfigDef.Range.atLeast(1),
+                ConfigDef.Importance.MEDIUM, "Max poll records", GROUP_OTHER, ++sourcePollingConfigCounter,
+                ConfigDef.Width.NONE, MAX_POLL_RECORDS);
+        // KIP-298 Error Handling in Connect
+        configDef.define(ERRORS_TOLERANCE, ConfigDef.Type.STRING, ErrorsTolerance.NONE.name(),
+                new ErrorsToleranceValidator(), ConfigDef.Importance.MEDIUM,
+                "Indicates to the connector what level of exceptions are allowed before the connector stops, supported values : none,all",
+                GROUP_OTHER, ++sourcePollingConfigCounter, ConfigDef.Width.NONE, ERRORS_TOLERANCE);
+
+        configDef.define(EXPECTED_MAX_MESSAGE_BYTES, ConfigDef.Type.INT, 1_048_588, ConfigDef.Importance.MEDIUM,
+                "The largest record batch size allowed by Kafka config max.message.bytes", GROUP_OTHER,
+                ++sourcePollingConfigCounter, ConfigDef.Width.NONE, EXPECTED_MAX_MESSAGE_BYTES);
+
+        configDef.define(FILE_NAME_TEMPLATE_CONFIG, ConfigDef.Type.STRING, null, null, ConfigDef.Importance.MEDIUM,
+                "The template for file names on S3. "
+                        + "Supports `{{ variable }}` placeholders for substituting variables. "
+                        + "Currently supported variables are `topic`, `partition`, and `start_offset` "
+                        + "(the offset of the first record in the file). "
+                        + "Only some combinations of variables are valid, which currently are:\n"
+                        + "- `topic`, `partition`, `start_offset`."
+                        + "There is also `*` only available when using `hash` distribution.",
+                GROUP_OTHER, ++sourcePollingConfigCounter, ConfigDef.Width.LONG, FILE_NAME_TEMPLATE_CONFIG);
 
         return configDef;
     }
 
+    @Override
+    public void validate() {
+        new SourcenameTemplateValidator(FILE_NAME_TEMPLATE_CONFIG, getDistributionType())
+                .ensureValid(FILE_NAME_TEMPLATE_CONFIG, getSourceName());
+    }
+
     public String getTargetTopic() {
         return cfg.getString(TARGET_TOPIC);
+    }
+    public String getSourceName() {
+        return cfg.getString(FILE_NAME_TEMPLATE_CONFIG);
     }
 
     public int getMaxPollRecords() {

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.config.validators;
+
+import static io.aiven.kafka.connect.common.config.FilenameTemplateVariable.PARTITION;
+import static io.aiven.kafka.connect.common.config.FilenameTemplateVariable.ParameterDescriptor;
+import static io.aiven.kafka.connect.common.config.FilenameTemplateVariable.START_OFFSET;
+import static io.aiven.kafka.connect.common.config.FilenameTemplateVariable.TIMESTAMP;
+import static io.aiven.kafka.connect.common.config.FilenameTemplateVariable.TOPIC;
+import static io.aiven.kafka.connect.common.grouper.RecordGrouperFactory.ALL_SUPPORTED_VARIABLES;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+import io.aiven.kafka.connect.common.source.task.DistributionType;
+import io.aiven.kafka.connect.common.templating.Template;
+
+import org.codehaus.plexus.util.StringUtils;
+
+public final class SourcenameTemplateValidator implements ConfigDef.Validator {
+
+    static final Map<String, ParameterDescriptor> SUPPORTED_VARIABLE_PARAMETERS = new LinkedHashMap<>();
+    static final Map<String, ParameterDescriptor> REQUIRED_VARIABLE_PARAMETERS = new LinkedHashMap<>();
+
+    static {
+        REQUIRED_VARIABLE_PARAMETERS.put(PARTITION.name, PARTITION.parameterDescriptor);
+        SUPPORTED_VARIABLE_PARAMETERS.putAll(REQUIRED_VARIABLE_PARAMETERS);
+        SUPPORTED_VARIABLE_PARAMETERS.put(START_OFFSET.name, START_OFFSET.parameterDescriptor);
+        SUPPORTED_VARIABLE_PARAMETERS.put(TIMESTAMP.name, TIMESTAMP.parameterDescriptor);
+        SUPPORTED_VARIABLE_PARAMETERS.put(TOPIC.name, TOPIC.parameterDescriptor);
+    }
+
+    private final String configName;
+    private final DistributionType distributionType;
+
+    public SourcenameTemplateValidator(final String configName, final DistributionType distributionType) {
+        this.configName = configName;
+        this.distributionType = distributionType;
+    }
+
+    @Override
+    public void ensureValid(final String name, final Object value) {
+        if (value == null) {
+            return;
+        }
+
+        assert value instanceof String;
+
+        // See https://cloud.google.com/storage/docs/naming
+        final String valueStr = (String) value;
+        if (valueStr.startsWith(".well-known/acme-challenge")) {
+            throw new ConfigException(configName, value, "cannot start with '.well-known/acme-challenge'");
+        }
+
+        if (StringUtils.isNotBlank(valueStr) && distributionType.equals(DistributionType.OBJECT_HASH)) {
+            // accepts any string or regex to match on.
+            return;
+        } else if (StringUtils.isBlank(valueStr)) {
+            throw new ConfigException(configName, "Can not be a blank or empty string");
+        }
+        // if using partition distribution it require the partition to be available.
+        try {
+            final Template template = Template.of((String) value);
+            validateVariables(template.variablesSet());
+            validateVariablesWithRequiredParameters(template.toString());
+        } catch (final IllegalArgumentException e) {
+            throw new ConfigException(configName, value, e.getMessage());
+        }
+    }
+
+    private static void validateVariables(final Set<String> variables) {
+        for (final String variable : variables) {
+            if (!ALL_SUPPORTED_VARIABLES.contains(variable)) {
+                throw new IllegalArgumentException(
+                        String.format("unsupported template variable used, supported values are: %s",
+                                SUPPORTED_VARIABLE_PARAMETERS.keySet()));
+            }
+        }
+    }
+
+    public static void validateVariablesWithRequiredParameters(final String sourceNameTemplate) {
+        for (final String requiredVariableParameter : REQUIRED_VARIABLE_PARAMETERS.keySet()) {
+            if (!sourceNameTemplate.contains(requiredVariableParameter)) {
+                throw new IllegalArgumentException(String
+                        .format("parameter %s is required for the the file.name.template", requiredVariableParameter));
+            }
+        }
+
+    }
+}

--- a/commons/src/test/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidatorTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidatorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.config.validators;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+
+import org.apache.kafka.common.config.ConfigException;
+
+import io.aiven.kafka.connect.common.source.task.DistributionType;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class SourcenameTemplateValidatorTest {
+    private static final String TEST_CONFIG_NAME = "TEST_CONFIG";
+
+    @ParameterizedTest
+    @CsvSource({ "{{topic}}-{{partition}}-{{start_offset}}.avro,partition", "*-{{partition}}.parquet,partition",
+            "*.gz,object_hash", "'([a-zA-Z0-9_-]{3,5}.gz',object_hash" })
+    void validateBasicSourceNamesPass(final String sourceName, final String distributionType) {
+        assertThatCode(
+                () -> new SourcenameTemplateValidator(TEST_CONFIG_NAME, DistributionType.forName(distributionType))
+                        .ensureValid(null, sourceName))
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "{{topic}}-{{start_offset}}.avro,partition,'Invalid value {{topic}}-{{start_offset}}.avro for configuration TEST_CONFIG: parameter partition is required for the the file.name.template'",
+            "*.parquet,partition,'Invalid value *.parquet for configuration TEST_CONFIG: parameter partition is required for the the file.name.template'",
+            "' ',object_hash,'Invalid value Can not be a blank or empty string for configuration TEST_CONFIG'" })
+    void validateVariableWithInvalidParameterName(final String sourceName, final String distributionType,
+            final String message) {
+
+        assertThatThrownBy(
+                () -> new SourcenameTemplateValidator(TEST_CONFIG_NAME, DistributionType.forName(distributionType))
+                        .ensureValid(null, sourceName))
+                .isInstanceOf(ConfigException.class)
+                .hasMessage(message);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "{{topic}}-{{long}}.avro,partition,'Invalid value {{topic}}-{{long}}.avro for configuration TEST_CONFIG: unsupported template variable used, supported values are: [partition, start_offset, timestamp, topic]'",
+            "{{filename}}-{{partition}}.parquet,partition,'Invalid value {{filename}}-{{partition}}.parquet for configuration TEST_CONFIG: unsupported template variable used, supported values are: [partition, start_offset, timestamp, topic]'", })
+    void validateCorrectExceptionsOnInvalidTemplates(final String sourceName, final String distributionType,
+            final String message) {
+
+        assertThatThrownBy(
+                () -> new SourcenameTemplateValidator(TEST_CONFIG_NAME, DistributionType.forName(distributionType))
+                        .ensureValid(null, sourceName))
+                .isInstanceOf(ConfigException.class)
+                .hasMessage(message);
+    }
+
+}

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/input/TransformerStreamingTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/input/TransformerStreamingTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 
 import io.aiven.kafka.connect.common.config.OutputFormatFragment;
 import io.aiven.kafka.connect.common.config.SourceCommonConfig;
+import io.aiven.kafka.connect.common.config.SourceConfigFragment;
 import io.aiven.kafka.connect.common.config.TransformerFragment;
 import io.aiven.kafka.connect.common.source.task.Context;
 
@@ -127,20 +128,23 @@ class TransformerStreamingTest {
         final var props = new HashMap<>();
         props.put(FORMAT_OUTPUT_TYPE_CONFIG.key(), "avro");
         lst.add(Arguments.of(TransformerFactory.getTransformer(InputFormat.AVRO),
-                AvroTransformerTest.generateMockAvroData(100).toByteArray(),
-                new SourceCommonConfig(OutputFormatFragment.update(new ConfigDef(), null), props) {
+                AvroTransformerTest.generateMockAvroData(100).toByteArray(), new SourceCommonConfig(
+                        SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null)), props) {
                 }, 100));
         lst.add(Arguments.of(TransformerFactory.getTransformer(InputFormat.BYTES),
-                "Hello World".getBytes(StandardCharsets.UTF_8), new SourceCommonConfig(
-                        TransformerFragment.update(OutputFormatFragment.update(new ConfigDef(), null)), props) {
+                "Hello World".getBytes(StandardCharsets.UTF_8),
+                new SourceCommonConfig(
+                        TransformerFragment.update(
+                                SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null))),
+                        props) {
                 }, 1));
         lst.add(Arguments.of(TransformerFactory.getTransformer(InputFormat.JSONL),
-                JsonTransformerTest.getJsonRecs(100).getBytes(StandardCharsets.UTF_8),
-                new SourceCommonConfig(OutputFormatFragment.update(new ConfigDef(), null), props) {
+                JsonTransformerTest.getJsonRecs(100).getBytes(StandardCharsets.UTF_8), new SourceCommonConfig(
+                        SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null)), props) {
                 }, 100));
         lst.add(Arguments.of(TransformerFactory.getTransformer(InputFormat.PARQUET),
-                ParquetTransformerTest.generateMockParquetData(),
-                new SourceCommonConfig(OutputFormatFragment.update(new ConfigDef(), null), props) {
+                ParquetTransformerTest.generateMockParquetData(), new SourceCommonConfig(
+                        SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null)), props) {
                 }, 100));
         return lst.stream();
     }

--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/AwsIntegrationTest.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/AwsIntegrationTest.java
@@ -279,6 +279,7 @@ class AwsIntegrationTest implements IntegrationBase {
         configData.put(TASK_ID, "0");
 
         configData.put(INPUT_FORMAT_KEY, InputFormat.BYTES.getValue());
+        configData.put(FILE_NAME_TEMPLATE_CONFIG, "{{topic}}-{{partition}}");
 
         final String testData1 = "Hello, Kafka Connect S3 Source! object 1";
         final String testData2 = "Hello, Kafka Connect S3 Source! object 2";

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfig.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfig.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigDef;
 
-import io.aiven.kafka.connect.common.config.FileNameFragment;
 import io.aiven.kafka.connect.common.config.OutputFieldType;
 import io.aiven.kafka.connect.common.config.OutputFormatFragment;
 import io.aiven.kafka.connect.common.config.SourceCommonConfig;
@@ -42,11 +41,9 @@ final public class S3SourceConfig extends SourceCommonConfig {
     public static final Logger LOGGER = LoggerFactory.getLogger(S3SourceConfig.class);
 
     private final S3ConfigFragment s3ConfigFragment;
-    private final FileNameFragment s3FileNameFragment;
     public S3SourceConfig(final Map<String, String> properties) {
         super(configDef(), handleDeprecatedYyyyUppercase(properties));
         s3ConfigFragment = new S3ConfigFragment(this);
-        s3FileNameFragment = new FileNameFragment(this);
         validate(); // NOPMD ConstructorCallsOverridableMethod getStsRole is called
     }
 
@@ -55,7 +52,6 @@ final public class S3SourceConfig extends SourceCommonConfig {
         final var configDef = new S3SourceConfigDef();
         S3ConfigFragment.update(configDef);
         SourceConfigFragment.update(configDef);
-        FileNameFragment.update(configDef);
         TransformerFragment.update(configDef);
         OutputFormatFragment.update(configDef, OutputFieldType.VALUE);
 
@@ -135,8 +131,8 @@ final public class S3SourceConfig extends SourceCommonConfig {
         return s3ConfigFragment;
     }
 
-    public FileNameFragment getS3FileNameFragment() {
-        return s3FileNameFragment;
+    public String getS3FilenameTemplate() {
+        return getSourcename();
     }
 
 }

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIterator.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIterator.java
@@ -169,8 +169,7 @@ public final class SourceRecordIterator implements Iterator<S3SourceRecord> {
         final DistributionType distributionType = s3SourceConfig.getDistributionType();
         final int maxTasks = s3SourceConfig.getMaxTasks();
         this.taskId = s3SourceConfig.getTaskId() % maxTasks;
-        this.filePattern = new FilePatternUtils(
-                s3SourceConfig.getS3FileNameFragment().getFilenameTemplate().toString());
+        this.filePattern = new FilePatternUtils(s3SourceConfig.getSourcename());
         return distributionType.getDistributionStrategy(maxTasks);
     }
 

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/S3SourceTaskTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/S3SourceTaskTest.java
@@ -43,6 +43,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 
+import io.aiven.kafka.connect.common.config.FileNameFragment;
 import io.aiven.kafka.connect.common.config.SourceConfigFragment;
 import io.aiven.kafka.connect.common.source.AbstractSourceTask;
 import io.aiven.kafka.connect.common.source.input.ByteArrayTransformer;
@@ -98,7 +99,8 @@ final class S3SourceTaskTest {
         commonProperties = Map.of(S3ConfigFragment.AWS_ACCESS_KEY_ID_CONFIG, "test_key_id",
                 S3ConfigFragment.AWS_SECRET_ACCESS_KEY_CONFIG, "test_secret_key",
                 S3ConfigFragment.AWS_S3_BUCKET_NAME_CONFIG, TEST_BUCKET, S3ConfigFragment.AWS_S3_ENDPOINT_CONFIG,
-                "http://localhost:" + s3Port, S3ConfigFragment.AWS_S3_REGION_CONFIG, "us-west-2");
+                "http://localhost:" + s3Port, S3ConfigFragment.AWS_S3_REGION_CONFIG, "us-west-2",
+                FileNameFragment.FILE_NAME_TEMPLATE_CONFIG, ".*");
 
         final AwsCredentialProviderFactory credentialFactory = new AwsCredentialProviderFactory();
         final S3SourceConfig config = new S3SourceConfig(commonProperties);

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIteratorTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/SourceRecordIteratorTest.java
@@ -36,13 +36,11 @@ import java.util.Queue;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import io.aiven.kafka.connect.common.config.FileNameFragment;
 import io.aiven.kafka.connect.common.source.OffsetManager;
 import io.aiven.kafka.connect.common.source.input.InputFormat;
 import io.aiven.kafka.connect.common.source.input.Transformer;
 import io.aiven.kafka.connect.common.source.input.TransformerFactory;
 import io.aiven.kafka.connect.common.source.task.DistributionType;
-import io.aiven.kafka.connect.common.templating.Template;
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -62,7 +60,6 @@ final class SourceRecordIteratorTest {
     private S3SourceConfig mockConfig;
     private OffsetManager mockOffsetManager;
     private Transformer mockTransformer;
-    private FileNameFragment mockFileNameFrag;
 
     private AWSV2SourceClient sourceApiClient;
 
@@ -71,7 +68,6 @@ final class SourceRecordIteratorTest {
         mockConfig = mock(S3SourceConfig.class);
         mockOffsetManager = mock(OffsetManager.class);
         mockTransformer = mock(Transformer.class);
-        mockFileNameFrag = mock(FileNameFragment.class);
     }
 
     private S3SourceConfig getConfig(final Map<String, String> data) {
@@ -85,8 +81,7 @@ final class SourceRecordIteratorTest {
         when(s3SourceConfig.getDistributionType()).thenReturn(DistributionType.OBJECT_HASH);
         when(s3SourceConfig.getTaskId()).thenReturn(taskId);
         when(s3SourceConfig.getMaxTasks()).thenReturn(maxTasks);
-        when(s3SourceConfig.getS3FileNameFragment()).thenReturn(mockFileNameFrag);
-        when(mockFileNameFrag.getFilenameTemplate()).thenReturn(Template.of(filePattern));
+        when(s3SourceConfig.getSourcename()).thenReturn(filePattern);
         when(mockConfig.getTargetTopic()).thenReturn(targetTopic);
         when(mockConfig.getTransformerMaxBufferSize()).thenReturn(4096);
         when(mockConfig.getS3FetchBufferSize()).thenReturn(1);


### PR DESCRIPTION
Allows better control of source file names to be selected by allowing just partition to be required on partition distribution and on object hash it only requires a non blank matching string that can be regex or exact matching.