### PR TITLE
Fixing tests to remove unexpected prefix that was not intended to be there

### DIFF
--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/AbstractSourceTaskTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/AbstractSourceTaskTest.java
@@ -121,6 +121,13 @@ class AbstractSourceTaskTest {
         }
     }
 
+    /**
+     * This test creates the condition where the delay increases until the expected delay will cause the maxDelay to be
+     * exceeded. The result is that the total delay should be the maxDelay not the higher calculated expected value.
+     *
+     * @throws InterruptedException
+     *             on interruption.
+     */
     @Test
     void backoffIncrementalTimeTest() throws InterruptedException {
         final AtomicBoolean abortTrigger = new AtomicBoolean();
@@ -140,11 +147,12 @@ class AbstractSourceTaskTest {
 
         final AbstractSourceTask.Backoff backoff = new AbstractSourceTask.Backoff(config);
         long expected = 2;
+        // estimated delay is the delay without jitter
         while (backoff.estimatedDelay() < maxDelay) {
             assertThat(backoff.estimatedDelay()).isEqualTo(expected);
             backoff.delay();
+            // delay may exit early due to induced jitter.
             expected *= 2;
-            assertThat(abortTrigger).isFalse();
         }
         assertThat(backoff.estimatedDelay()).isEqualTo(maxDelay);
     }

--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/AwsIntegrationTest.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/AwsIntegrationTest.java
@@ -154,10 +154,10 @@ class AwsIntegrationTest implements IntegrationBase {
         final List<String> offsetKeys = new ArrayList<>();
         final List<String> expectedKeys = new ArrayList<>();
         // write 2 objects to s3
-        expectedKeys.add(writeToS3(topic, testData1.getBytes(StandardCharsets.UTF_8), "00000"));
-        expectedKeys.add(writeToS3(topic, testData2.getBytes(StandardCharsets.UTF_8), "00000"));
-        expectedKeys.add(writeToS3(topic, testData1.getBytes(StandardCharsets.UTF_8), "00001"));
-        expectedKeys.add(writeToS3(topic, testData2.getBytes(StandardCharsets.UTF_8), "00001"));
+        expectedKeys.add(writeToS3(topic, testData1.getBytes(StandardCharsets.UTF_8), "00000", s3Prefix));
+        expectedKeys.add(writeToS3(topic, testData2.getBytes(StandardCharsets.UTF_8), "00000", s3Prefix));
+        expectedKeys.add(writeToS3(topic, testData1.getBytes(StandardCharsets.UTF_8), "00001", s3Prefix));
+        expectedKeys.add(writeToS3(topic, testData2.getBytes(StandardCharsets.UTF_8), "00001", s3Prefix));
 
         // we don't expext the empty one.
         offsetKeys.addAll(expectedKeys);
@@ -224,12 +224,12 @@ class AwsIntegrationTest implements IntegrationBase {
 
         final Set<String> offsetKeys = new HashSet<>();
 
-        offsetKeys.add(writeToS3(topic, outputStream1, "00001"));
-        offsetKeys.add(writeToS3(topic, outputStream2, "00001"));
+        offsetKeys.add(writeToS3(topic, outputStream1, "00001", s3Prefix));
+        offsetKeys.add(writeToS3(topic, outputStream2, "00001", s3Prefix));
 
-        offsetKeys.add(writeToS3(topic, outputStream3, "00002"));
-        offsetKeys.add(writeToS3(topic, outputStream4, "00002"));
-        offsetKeys.add(writeToS3(topic, outputStream5, "00002"));
+        offsetKeys.add(writeToS3(topic, outputStream3, "00002", s3Prefix));
+        offsetKeys.add(writeToS3(topic, outputStream4, "00002", s3Prefix));
+        offsetKeys.add(writeToS3(topic, outputStream5, "00002", s3Prefix));
 
         assertThat(testBucketAccessor.listObjects()).hasSize(5);
 
@@ -289,8 +289,8 @@ class AwsIntegrationTest implements IntegrationBase {
         final List<String> actualKeys = new ArrayList<>();
 
         // write 2 objects to s3
-        expectedKeys.add(writeToS3(topic, testData1.getBytes(StandardCharsets.UTF_8), "00000"));
-        expectedKeys.add(writeToS3(topic, testData2.getBytes(StandardCharsets.UTF_8), "00000"));
+        expectedKeys.add(writeToS3(topic, testData1.getBytes(StandardCharsets.UTF_8), "00000", s3Prefix));
+        expectedKeys.add(writeToS3(topic, testData2.getBytes(StandardCharsets.UTF_8), "00000", s3Prefix));
 
         assertThat(testBucketAccessor.listObjects()).hasSize(2);
 
@@ -309,7 +309,7 @@ class AwsIntegrationTest implements IntegrationBase {
         assertThat(actualKeys).containsAll(expectedKeys);
 
         // write 3rd object to s3
-        expectedKeys.add(writeToS3(topic, testData3.getBytes(StandardCharsets.UTF_8), "00000"));
+        expectedKeys.add(writeToS3(topic, testData3.getBytes(StandardCharsets.UTF_8), "00000", s3Prefix));
         assertThat(testBucketAccessor.listObjects()).hasSize(3);
 
         assertThat(iterator).hasNext();

--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationBase.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationBase.java
@@ -153,7 +153,7 @@ public interface IntegrationBase {
      *         {@link OffsetManager}
      */
     default String writeToS3(final String topic, final byte[] testDataBytes, final String partitionId) {
-        return writeToS3(topic, testDataBytes, partitionId, getS3Prefix());
+        return writeToS3(topic, testDataBytes, partitionId, null);
 
     }
 

--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationTest.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/IntegrationTest.java
@@ -244,7 +244,7 @@ final class IntegrationTest implements IntegrationBase {
         }
         final List<String> offsetKeys = new ArrayList<>();
 
-        offsetKeys.add(writeToS3(topic, testData1, "0", s3Prefix));
+        offsetKeys.add(writeToS3(topic, testData1, "0"));
 
         assertThat(testBucketAccessor.listObjects()).hasSize(1);
 


### PR DESCRIPTION
Previously a writeToS3 method was adding an unexpected prefix.
This now does not add the prefix to the integration tests where it is not expected.