### PR TITLE
Make AzureBlobSourceTask constructor public for Connect compatibility

### DIFF
--- a/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/AzureBlobSourceTask.java
+++ b/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/AzureBlobSourceTask.java
@@ -33,11 +33,12 @@ import org.slf4j.LoggerFactory;
 public class AzureBlobSourceTask extends AbstractSourceTask {
     /* The logger to write to */
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureBlobSourceTask.class);
+
     /**
-     * Constructor to set the Logger used.
+     * Constructor to set the Logger used. This constructor is required by Connect.
      *
      */
-    protected AzureBlobSourceTask() {
+    public AzureBlobSourceTask() {
         super(LOGGER);
     }
     private AzureBlobSourceConfig azureBlobSourceConfig; // NOPMD only called once, when used in the future this can be


### PR DESCRIPTION
It fixes the following exception occuring at task startup for Azure blob source connector:
```
org.apache.kafka.connect.errors.ConnectException: Instantiation error
	at org.apache.kafka.connect.runtime.isolation.Plugins.newPlugin(Plugins.java:141)
	at org.apache.kafka.connect.runtime.isolation.Plugins.newTask(Plugins.java:339)
	at org.apache.kafka.connect.runtime.Worker.startTask(Worker.java:663)
	at org.apache.kafka.connect.runtime.Worker.startSourceTask(Worker.java:591)
	at org.apache.kafka.connect.runtime.distributed.DistributedHerder.startTask(DistributedHerder.java:2039)
	at org.apache.kafka.connect.runtime.distributed.DistributedHerder.lambda$getTaskStartingCallable$39(DistributedHerder.java:2056)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: org.apache.kafka.common.KafkaException: Could not instantiate class io.aiven.kafka.connect.azure.source.AzureBlobSourceTask
	at org.apache.kafka.common.utils.Utils.newInstance(Utils.java:403)
	at org.apache.kafka.connect.runtime.isolation.Plugins.newPlugin(Plugins.java:139)
	... 9 more
Caused by: java.lang.IllegalAccessException: class org.apache.kafka.common.utils.Utils cannot access a member of class io.aiven.kafka.connect.azure.source.AzureBlobSourceTask with modifiers "protected"
	at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:392)
	at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:674)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:490)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
	at org.apache.kafka.common.utils.Utils.newInstance(Utils.java:399)
	... 10 more
```