### PR TITLE
changes to remove Outputformat from source config

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/FileNameFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/FileNameFragment.java
@@ -55,11 +55,9 @@ public final class FileNameFragment extends ConfigFragment {
 
     /**
      * Validate the distribution type works with the file name template.
-     *
-     * @param distributionType
-     *            the distribution type for the validator
+     * @param distributionType the distribution type for the validator
      */
-    public void validateDistributionType(final DistributionType distributionType) {
+    public void validateDistributionType(DistributionType distributionType) {
         new SourcenameTemplateValidator(FILE_NAME_TEMPLATE_CONFIG, distributionType).ensureValid("", getSourceName());
     }
 

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/FileNameFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/FileNameFragment.java
@@ -20,17 +20,17 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.stream.Collectors;
 
-import io.aiven.kafka.connect.common.config.validators.SourcenameTemplateValidator;
-import io.aiven.kafka.connect.common.source.task.DistributionType;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.connect.common.config.validators.FileCompressionTypeValidator;
 import io.aiven.kafka.connect.common.config.validators.FilenameTemplateValidator;
+import io.aiven.kafka.connect.common.config.validators.SourcenameTemplateValidator;
 import io.aiven.kafka.connect.common.config.validators.TimeZoneValidator;
 import io.aiven.kafka.connect.common.config.validators.TimestampSourceValidator;
 import io.aiven.kafka.connect.common.grouper.RecordGrouperFactory;
+import io.aiven.kafka.connect.common.source.task.DistributionType;
 import io.aiven.kafka.connect.common.templating.Template;
 
 /**
@@ -56,9 +56,11 @@ public final class FileNameFragment extends ConfigFragment {
 
     /**
      * Validate the distribution type works with the file name template.
-     * @param distributionType the distribution type for the validator
+     *
+     * @param distributionType
+     *            the distribution type for the validator
      */
-    public void validateDistributionType(DistributionType distributionType) {
+    public void validateDistributionType(final DistributionType distributionType) {
         new SourcenameTemplateValidator(FILE_NAME_TEMPLATE_CONFIG, distributionType).ensureValid("", getSourceName());
     }
 
@@ -144,7 +146,6 @@ public final class FileNameFragment extends ConfigFragment {
     public void validate() {
         throw new ConfigException("Do not call FileNameFragment.validate() -- call sink/source specific validator");
     }
-
 
     /**
      * Returns the text of the filename template. May throw {@link ConfigException} if the property

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/FileNameFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/FileNameFragment.java
@@ -55,9 +55,11 @@ public final class FileNameFragment extends ConfigFragment {
 
     /**
      * Validate the distribution type works with the file name template.
-     * @param distributionType the distribution type for the validator
+     *
+     * @param distributionType
+     *            the distribution type for the validator
      */
-    public void validateDistributionType(DistributionType distributionType) {
+    public void validateDistributionType(final DistributionType distributionType) {
         new SourcenameTemplateValidator(FILE_NAME_TEMPLATE_CONFIG, distributionType).ensureValid("", getSourceName());
     }
 

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SinkCommonConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SinkCommonConfig.java
@@ -52,7 +52,7 @@ public class SinkCommonConfig extends CommonConfig {
 
     private void validate() {
         outputFormatFragment.validate();
-        fileNameFragment.validate();
+        fileNameFragment.validateRecordGrouper();
     }
 
     protected static void addOutputFieldsFormatConfigGroup(final ConfigDef configDef,

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
@@ -32,7 +32,6 @@ public class SourceCommonConfig extends CommonConfig {
     private final SourceConfigFragment sourceConfigFragment;
     private final FileNameFragment fileNameFragment;
 
-
     public SourceCommonConfig(ConfigDef definition, Map<?, ?> originals) {// NOPMD
         super(definition, originals);
         // Construct Fragments

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
@@ -30,14 +30,14 @@ public class SourceCommonConfig extends CommonConfig {
 
     private final TransformerFragment transformerFragment;
     private final SourceConfigFragment sourceConfigFragment;
-    private final OutputFormatFragment outputFormatFragment;
+    private final FileNameFragment fileNameFragment;
 
     public SourceCommonConfig(ConfigDef definition, Map<?, ?> originals) {// NOPMD
         super(definition, originals);
         // Construct Fragments
         transformerFragment = new TransformerFragment(this);
         sourceConfigFragment = new SourceConfigFragment(this);
-        outputFormatFragment = new OutputFormatFragment(this);
+        fileNameFragment = new FileNameFragment(this);
 
         validate(); // NOPMD ConstructorCallsOverridableMethod
     }
@@ -45,7 +45,7 @@ public class SourceCommonConfig extends CommonConfig {
     private void validate() {
         transformerFragment.validate();
         sourceConfigFragment.validate();
-        outputFormatFragment.validate();
+        fileNameFragment.validateDistributionType(getDistributionType());
     }
 
     public InputFormat getInputFormat() {
@@ -80,7 +80,7 @@ public class SourceCommonConfig extends CommonConfig {
         return transformerFragment.getTransformerMaxBufferSize();
     }
 
-    public String getSourcename() {
+    public String getSourceName() {
         return sourceConfigFragment.getSourceName();
     }
 

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceConfigFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceConfigFragment.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
 import io.aiven.kafka.connect.common.config.enums.ErrorsTolerance;
-import io.aiven.kafka.connect.common.config.validators.SourcenameTemplateValidator;
 import io.aiven.kafka.connect.common.source.task.DistributionType;
 
 import org.apache.commons.lang3.StringUtils;
@@ -87,15 +86,10 @@ public final class SourceConfigFragment extends ConfigFragment {
         return configDef;
     }
 
-    @Override
-    public void validate() {
-        new SourcenameTemplateValidator(FILE_NAME_TEMPLATE_CONFIG, getDistributionType())
-                .ensureValid(FILE_NAME_TEMPLATE_CONFIG, getSourceName());
-    }
-
     public String getTargetTopic() {
         return cfg.getString(TARGET_TOPIC);
     }
+
     public String getSourceName() {
         return cfg.getString(FILE_NAME_TEMPLATE_CONFIG);
     }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
@@ -27,13 +27,12 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.connect.common.source.task.DistributionType;
 import io.aiven.kafka.connect.common.templating.Template;
-
-import org.apache.commons.lang3.StringUtils;
 
 public final class SourcenameTemplateValidator implements ConfigDef.Validator {
 

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
@@ -27,13 +27,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.connect.common.source.task.DistributionType;
 import io.aiven.kafka.connect.common.templating.Template;
 
-import org.codehaus.plexus.util.StringUtils;
 
 public final class SourcenameTemplateValidator implements ConfigDef.Validator {
 
@@ -76,7 +76,7 @@ public final class SourcenameTemplateValidator implements ConfigDef.Validator {
         } else if (StringUtils.isBlank(valueStr)) {
             throw new ConfigException(configName, "Can not be a blank or empty string");
         }
-        // if using partition distribution it require the partition to be available.
+        // if using partition distribution it requires the partition to be available.
         try {
             final Template template = Template.of((String) value);
             validateVariables(template.variablesSet());

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
@@ -27,13 +27,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.connect.common.source.task.DistributionType;
 import io.aiven.kafka.connect.common.templating.Template;
 
+import org.apache.commons.lang3.StringUtils;
 
 public final class SourcenameTemplateValidator implements ConfigDef.Validator {
 

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
@@ -27,12 +27,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.connect.common.source.task.DistributionType;
 import io.aiven.kafka.connect.common.templating.Template;
+
+import org.apache.commons.lang3.StringUtils;
 
 public final class SourcenameTemplateValidator implements ConfigDef.Validator {
 

--- a/commons/src/main/java/io/aiven/kafka/connect/common/source/AbstractSourceRecordIterator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/source/AbstractSourceRecordIterator.java
@@ -119,7 +119,7 @@ public abstract class AbstractSourceRecordIterator<N, K extends Comparable<K>, O
         this.targetTopics = Optional.ofNullable(sourceConfig.getTargetTopic());
         this.taskId = sourceConfig.getTaskId() % maxTasks;
         this.taskAssignment = new TaskAssignment(distributionType.getDistributionStrategy(maxTasks));
-        this.fileMatching = new FileMatching(new FilePatternUtils(sourceConfig.getSourcename()));
+        this.fileMatching = new FileMatching(new FilePatternUtils(sourceConfig.getSourceName()));
         this.inner = Collections.emptyIterator();
         this.outer = Collections.emptyIterator();
         this.ringBuffer = new RingBuffer<>(Math.max(1, bufferSize));

--- a/commons/src/test/java/io/aiven/kafka/connect/common/config/FileNameFragmentTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/config/FileNameFragmentTest.java
@@ -131,7 +131,7 @@ public class FileNameFragmentTest {// NOPMD
         props.put(FileNameFragment.FILE_MAX_RECORDS, "50");
         final AbstractConfig cfg = new AbstractConfig(configDef, props);
         final FileNameFragment underTest = new FileNameFragment(cfg);
-        assertThatThrownBy(() -> underTest.validate()).isInstanceOf(ConfigException.class);
+        assertThatThrownBy(underTest::validateRecordGrouper).isInstanceOf(ConfigException.class);
     }
 
     @ParameterizedTest(name = "{index} {0}")

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/TaskAssignmentTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/TaskAssignmentTest.java
@@ -53,7 +53,7 @@ class TaskAssignmentTest {
         when(mockConfig.getMaxTasks()).thenReturn(maxTasks);
         when(mockConfig.getTargetTopic()).thenReturn("topic");
         when(mockConfig.getTransformerMaxBufferSize()).thenReturn(4096);
-        when(mockConfig.getSourcename()).thenReturn("{{topic}}-{{partition}}-{{start_offset}}");
+        when(mockConfig.getSourceName()).thenReturn("{{topic}}-{{partition}}-{{start_offset}}");
         return mockConfig;
     }
 

--- a/commons/src/testFixtures/java/io/aiven/kafka/connect/common/source/AbstractSourceRecordIteratorTest.java
+++ b/commons/src/testFixtures/java/io/aiven/kafka/connect/common/source/AbstractSourceRecordIteratorTest.java
@@ -153,7 +153,7 @@ public abstract class AbstractSourceRecordIteratorTest<N, K extends Comparable<K
         when(mockConfig.getMaxTasks()).thenReturn(maxTasks);
         when(mockConfig.getTargetTopic()).thenReturn(targetTopic);
         when(mockConfig.getTransformerMaxBufferSize()).thenReturn(4096);
-        when(mockConfig.getSourcename()).thenReturn(filePattern);
+        when(mockConfig.getSourceName()).thenReturn(filePattern);
         return mockConfig;
     }
 


### PR DESCRIPTION
OutputFormatFragment should not contribute to source configuration.  This change removes the output format from the source configurations and addresses the validation of output restrictions on FileNameFragment vs the input restrictions on FileNameFragment.