### PR TITLE
Adds Fragment Setters.

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/AbstractFragmentSetter.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/AbstractFragmentSetter.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.config;
+
+import java.net.URI;
+import java.util.Map;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * An abstract class that is the bases for programmatic configuration easier.
+ *
+ * @param <T>
+ *            the concrete class.
+ */
+@SuppressWarnings("PMD.LinguisticNaming")
+public class AbstractFragmentSetter<T extends AbstractFragmentSetter<T>> {
+    /** The data being set */
+    private final Map<String, String> dataMap;
+
+    /**
+     * Constructor.
+     *
+     * @param data
+     *            the map of data items being set.
+     */
+    protected AbstractFragmentSetter(final Map<String, String> data) {
+        this.dataMap = data;
+    }
+
+    /**
+     * Gets the data map.
+     *
+     * @return the data map.
+     */
+    @SuppressFBWarnings(value = { "EI_EXPOSE_REP", "EI_EXPOSE_REP2" }, justification = "returning data as modified")
+    final public Map<String, String> data() {
+        return dataMap;
+    }
+
+    /**
+     * Sets the value.
+     *
+     * @param key
+     *            the key to set the value for.
+     * @param value
+     *            the value to set.
+     * @return this.
+     */
+    final protected T setValue(final String key, final String value) {
+        dataMap.put(key, value);
+        return (T) this;
+    }
+
+    /**
+     * Sets the value.
+     *
+     * @param key
+     *            the key to set the value for.
+     * @param value
+     *            the value to set.
+     * @return this.
+     */
+    final protected T setValue(final String key, final int value) {
+        return setValue(key, Integer.toString(value));
+    }
+
+    /**
+     * Sets the value.
+     *
+     * @param key
+     *            the key to set the value for.
+     * @param value
+     *            the value to set.
+     * @return this.
+     */
+    final protected T setValue(final String key, final long value) {
+        return setValue(key, Long.toString(value));
+    }
+
+    /**
+     * Sets the value.
+     *
+     * @param key
+     *            the key to set the value for.
+     * @param value
+     *            the value to set.
+     * @return this.
+     */
+    final protected T setValue(final String key, final Class<?> value) {
+        return setValue(key, value.getCanonicalName());
+    }
+
+    /**
+     * Sets the value.
+     *
+     * @param key
+     *            the key to set the value for.
+     * @param value
+     *            the value to set.
+     * @return this.
+     */
+    final protected T setValue(final String key, final URI value) {
+        return setValue(key, value.toString());
+    }
+
+    /**
+     * Sets the value.
+     *
+     * @param key
+     *            the key to set the value for.
+     * @param state
+     *            the value to set.
+     * @return this.
+     */
+    final protected T setValue(final String key, final boolean state) {
+        return setValue(key, Boolean.toString(state));
+    }
+}

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/ConfigFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/ConfigFragment.java
@@ -16,7 +16,11 @@
 
 package io.aiven.kafka.connect.common.config;
 
+import static java.lang.String.format;
+
 import org.apache.kafka.common.config.AbstractConfig;
+
+import org.slf4j.Logger;
 
 /**
  * Config fragments encapsulate logical fragments of configuration that may be used across multiple Connectors or across
@@ -40,7 +44,48 @@ public class ConfigFragment {
     protected final AbstractConfig cfg;
 
     /**
-     * Construct the ConfigFragment..
+     * Logs a deprecated message for a deprecated configuration key.
+     *
+     * @param logger
+     *            the logger to log to.
+     * @param old
+     *            the deprecated configuration key.
+     * @param replacement
+     *            the replacement configuration key.
+     */
+    public static void logDeprecated(final Logger logger, final String old, final String replacement) {
+        logDeprecated(logger, old, "Use property %s instead", replacement);
+    }
+
+    /**
+     * Logs a deprecated message for a deprecated configuration key. This method should only be used when the key does
+     * not have a replacement and the documentation describes what to do.
+     *
+     * @param logger
+     *            the logger to log to.
+     * @param old
+     *            the deprecated configuration key.
+     */
+    public static void logDeprecated(final Logger logger, final String old, final String formatStr,
+            final Object... args) {
+        logger.warn("{} property is deprecated. {}", old, format(formatStr, args));
+    }
+
+    /**
+     * Logs a deprecated message for a deprecated configuration key. This method should only be used when the key does
+     * not have a replacement and the documentation describes what to do.
+     *
+     * @param logger
+     *            the logger to log to.
+     * @param old
+     *            the deprecated configuration key.
+     */
+    public static void logDeprecated(final Logger logger, final String old) {
+        logger.warn("{} property is deprecated please read documentation for the new name.", old);
+    }
+
+    /**
+     * Construct the ConfigFragment.
      *
      * @param cfg
      *            the configuration that this fragment is associated with.

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/FileNameFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/FileNameFragment.java
@@ -18,13 +18,13 @@ package io.aiven.kafka.connect.common.config;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Map;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.connect.common.config.validators.FileCompressionTypeValidator;
-import io.aiven.kafka.connect.common.config.validators.FilenameTemplateValidator;
 import io.aiven.kafka.connect.common.config.validators.SourcenameTemplateValidator;
 import io.aiven.kafka.connect.common.config.validators.TimeZoneValidator;
 import io.aiven.kafka.connect.common.config.validators.TimestampSourceValidator;
@@ -49,6 +49,23 @@ public final class FileNameFragment extends ConfigFragment {
 
     public static final String FILE_PATH_PREFIX_TEMPLATE_CONFIG = "file.prefix.template";
 
+    /**
+     * Gets a setter for this properties in this fragment.
+     *
+     * @param data
+     *            the data to update.
+     * @return the Setter.
+     */
+    public static Setter setter(final Map<String, String> data) {
+        return new Setter(data);
+    }
+
+    /**
+     * Create an instance of this fragment wrapping the specified config.
+     *
+     * @param cfg
+     *            the configuration to read from.
+     */
     public FileNameFragment(final AbstractConfig cfg) {
         super(cfg);
     }
@@ -60,7 +77,7 @@ public final class FileNameFragment extends ConfigFragment {
      *            the distribution type for the validator
      */
     public void validateDistributionType(final DistributionType distributionType) {
-        new SourcenameTemplateValidator(FILE_NAME_TEMPLATE_CONFIG, distributionType).ensureValid("", getSourceName());
+        new SourcenameTemplateValidator(distributionType).ensureValid(FILE_NAME_TEMPLATE_CONFIG, getSourceName());
     }
 
     /**
@@ -87,40 +104,62 @@ public final class FileNameFragment extends ConfigFragment {
      * @return the updated configuration definition.
      */
     public static ConfigDef update(final ConfigDef configDef) {
+        return update(configDef, CompressionType.NONE);
+    }
+
+    /**
+     * Adds the FileName properties to the configuration definition.
+     *
+     * @param configDef
+     *            the configuration definition to update.
+     * @param defaultCompressionType
+     *            The default compression type. May be {@code null}.
+     * @return the updated configuration definition.
+     */
+    public static ConfigDef update(final ConfigDef configDef, final CompressionType defaultCompressionType) {
         int fileGroupCounter = 0;
 
-        configDef.define(FILE_NAME_TEMPLATE_CONFIG, ConfigDef.Type.STRING, null,
-                new FilenameTemplateValidator(FILE_NAME_TEMPLATE_CONFIG), ConfigDef.Importance.MEDIUM,
-                "The template for file names. Supports `{{ variable }}` placeholders for substituting variables. "
+        configDef.define(FILE_NAME_TEMPLATE_CONFIG, ConfigDef.Type.STRING, null, null, ConfigDef.Importance.MEDIUM,
+                "The template for file names on storage system. "
+                        + "Supports `{{ variable }}` placeholders for substituting variables. "
                         + "Currently supported variables are `topic`, `partition`, and `start_offset` "
                         + "(the offset of the first record in the file). "
                         + "Only some combinations of variables are valid, which currently are:\n"
                         + "- `topic`, `partition`, `start_offset`."
                         + "There is also `key` only variable {{key}} for grouping by keys",
-                GROUP_FILE, fileGroupCounter++, ConfigDef.Width.LONG, FILE_NAME_TEMPLATE_CONFIG);
+                GROUP_FILE, ++fileGroupCounter, ConfigDef.Width.LONG, FILE_NAME_TEMPLATE_CONFIG);
+
+        configDef.define(FILE_PATH_PREFIX_TEMPLATE_CONFIG, ConfigDef.Type.STRING, null, null,
+                ConfigDef.Importance.MEDIUM,
+                "The template for file names prefixes on storage system. "
+                        + "Supports `{{ variable }}` placeholders for substituting variables. "
+                        + "Currently supported variables are `topic`, `partition`, and `start_offset` "
+                        + "(the offset of the first record in the file). "
+                        + "Only some combinations of variables are valid, which currently are:\n"
+                        + "- `topic`, `partition`, `start_offset`."
+                        + "There is also `key` only variable {{key}} for grouping by keys",
+                GROUP_FILE, ++fileGroupCounter, ConfigDef.Width.LONG, FILE_PATH_PREFIX_TEMPLATE_CONFIG);
 
         configDef.define(FILE_COMPRESSION_TYPE_CONFIG, ConfigDef.Type.STRING, null, new FileCompressionTypeValidator(),
                 ConfigDef.Importance.MEDIUM, "The compression type used for files.", GROUP_FILE, fileGroupCounter++,
                 ConfigDef.Width.NONE, FILE_COMPRESSION_TYPE_CONFIG,
                 FixedSetRecommender.ofSupportedValues(CompressionType.names()));
 
-        configDef.define(FILE_MAX_RECORDS, ConfigDef.Type.INT, 0, ConfigDef.Range.atLeast(0),
+        configDef.define(FILE_MAX_RECORDS, ConfigDef.Type.INT, 0, ConfigDef.Range.between(0, Integer.MAX_VALUE),
                 ConfigDef.Importance.MEDIUM,
                 "The maximum number of records to put in a single file. " + "Must be a non-negative integer number. "
                         + "0 is interpreted as \"unlimited\", which is the default.",
-                GROUP_FILE, fileGroupCounter++, ConfigDef.Width.SHORT, FILE_MAX_RECORDS);
+                GROUP_FILE, ++fileGroupCounter, ConfigDef.Width.SHORT, FILE_MAX_RECORDS);
 
         configDef.define(FILE_NAME_TIMESTAMP_TIMEZONE, ConfigDef.Type.STRING, ZoneOffset.UTC.toString(),
                 new TimeZoneValidator(), ConfigDef.Importance.LOW,
                 "Specifies the timezone in which the dates and time for the timestamp variable will be treated. "
                         + "Use standard shot and long names. Default is UTC",
-                GROUP_FILE, fileGroupCounter++, // NOPMD UnusedAssignment
-                ConfigDef.Width.SHORT, FILE_NAME_TIMESTAMP_TIMEZONE);
+                GROUP_FILE, ++fileGroupCounter, ConfigDef.Width.SHORT, FILE_NAME_TIMESTAMP_TIMEZONE);
 
         configDef.define(FILE_NAME_TIMESTAMP_SOURCE, ConfigDef.Type.STRING, TimestampSource.Type.WALLCLOCK.name(),
                 new TimestampSourceValidator(), ConfigDef.Importance.LOW,
-                "Specifies the the timestamp variable source. Default is wall-clock.", GROUP_FILE, fileGroupCounter++, // NOPMD
-                                                                                                                       // UnusedAssignment
+                "Specifies the the timestamp variable source. Default is wall-clock.", GROUP_FILE, ++fileGroupCounter,
                 ConfigDef.Width.SHORT, FILE_NAME_TIMESTAMP_SOURCE);
 
         return configDef;
@@ -141,10 +180,21 @@ public final class FileNameFragment extends ConfigFragment {
         if (has(FILE_NAME_TEMPLATE_CONFIG)) {
             return cfg.getString(FILE_NAME_TEMPLATE_CONFIG);
         }
-        final CompressionType compressionType = new CompressionFragment(cfg).getCompressionType();
+        final CompressionType compressionType = getCompressionType();
         return FormatType.AVRO.equals(new OutputFormatFragment(cfg).getFormatType())
                 ? DEFAULT_FILENAME_TEMPLATE + ".avro" + compressionType.extension()
                 : DEFAULT_FILENAME_TEMPLATE + compressionType.extension();
+    }
+
+    /**
+     * Retrieves the defined compression type.
+     *
+     * @return the defined compression type or {@link CompressionType#NONE} if there is no defined compression type.
+     */
+    public CompressionType getCompressionType() {
+        return has(FILE_COMPRESSION_TYPE_CONFIG)
+                ? CompressionType.forName(cfg.getString(FILE_COMPRESSION_TYPE_CONFIG))
+                : CompressionType.NONE;
     }
 
     /**
@@ -188,4 +238,99 @@ public final class FileNameFragment extends ConfigFragment {
         return cfg.getString(FILE_NAME_TEMPLATE_CONFIG);
     }
 
+    public String getPrefixTemplate() {
+        return cfg.getString(FILE_PATH_PREFIX_TEMPLATE_CONFIG);
+    }
+
+    /**
+     * Setter for the FileNameFragment.
+     */
+    public static final class Setter extends AbstractFragmentSetter<Setter> {
+        /**
+         * Constructs the Setter.
+         *
+         * @param data
+         *            the data to update.
+         */
+        private Setter(final Map<String, String> data) {
+            super(data);
+        }
+
+        /**
+         * Sets the file compression type.
+         *
+         * @param compressionType
+         *            the compression type.
+         * @return this
+         */
+        public Setter fileCompression(final CompressionType compressionType) {
+            return setValue(FILE_COMPRESSION_TYPE_CONFIG, compressionType.name());
+        }
+
+        /**
+         * Sets the maximum records per file.
+         *
+         * @param maxRecordsPerFile
+         *            the maximum records per file.
+         * @return this.
+         */
+        public Setter maxRecordsPerFile(final int maxRecordsPerFile) {
+            return setValue(FILE_MAX_RECORDS, maxRecordsPerFile);
+        }
+
+        /**
+         * Sets the time stamp source.
+         *
+         * @param timestampSource
+         *            the time stamp source.
+         * @return this.
+         */
+        public Setter timestampSource(final TimestampSource timestampSource) {
+            return setValue(FILE_NAME_TIMESTAMP_SOURCE, timestampSource.type().name());
+        }
+
+        /**
+         * Sets the timestamp source from a type.
+         *
+         * @param type
+         *            the type to set the timestamp source to.
+         * @return this.
+         */
+        public Setter timestampSource(final TimestampSource.Type type) {
+            return setValue(FILE_NAME_TIMESTAMP_SOURCE, type.name());
+        }
+
+        /**
+         * Sets the timestamp timezone.
+         *
+         * @param timeZone
+         *            the timezone to se.t
+         * @return this
+         */
+        public Setter timestampTimeZone(final ZoneId timeZone) {
+            return setValue(FILE_NAME_TIMESTAMP_TIMEZONE, timeZone.toString());
+        }
+
+        /**
+         * Sets the file name template.
+         *
+         * @param template
+         *            the prefix template to use.
+         * @return this.
+         */
+        public Setter template(final String template) {
+            return setValue(FILE_NAME_TEMPLATE_CONFIG, template);
+        }
+
+        /**
+         * Sets the file name prefix template.
+         *
+         * @param prefixTemplate
+         *            the prefix template to use.
+         * @return this
+         */
+        public Setter prefixTemplate(final String prefixTemplate) {
+            return setValue(FILE_PATH_PREFIX_TEMPLATE_CONFIG, prefixTemplate);
+        }
+    }
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/KafkaFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/KafkaFragment.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2025 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.config;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.storage.Converter;
+
+/**
+ * Defines the configuration for Kafka. This fragment only has the Setter and a few constants for Connectors.
+ */
+public final class KafkaFragment {
+
+    /**
+     * Enum for setting discovery.
+     */
+    public enum PluginDiscovery {
+        ONLY_SCAN, SERVICE_LOAD, HYBRID_WARN, HYBRID_FAIL
+    }
+
+    /**
+     * The configuration string for plugin discovery.
+     */
+    private final static String PLUGIN_DISCOVERY = "plugin.discovery";
+
+    private KafkaFragment() {
+        // do not instantiate.
+    }
+
+    /**
+     * Get the setter for this fragment.
+     *
+     * @param data
+     *            The data map for the configuration.
+     * @return the Setter.
+     */
+    public static Setter setter(final Map<String, String> data) {
+        return new Setter(data);
+    }
+
+    /**
+     * The setter class to set options in a data map for the configuration.
+     */
+    @SuppressWarnings("PMD.TooManyMethods")
+    public final static class Setter extends AbstractFragmentSetter<Setter> {
+        /**
+         * Constructor.
+         *
+         * @param data
+         *            the map of data to update.
+         */
+        private Setter(final Map<String, String> data) {
+            super(data);
+        }
+
+        /**
+         * THe class for the connector.
+         *
+         * @param connectorClass
+         *            the class for the connector.
+         * @return this
+         */
+        public Setter connector(final Class<? extends Connector> connectorClass) {
+            return setValue(ConnectorConfig.CONNECTOR_CLASS_CONFIG, connectorClass);
+        }
+
+        /**
+         * Sets the key converter.
+         *
+         * @param converter
+         *            the Key converter class.
+         * @return this
+         */
+        public Setter keyConverter(final Class<? extends Converter> converter) {
+            return setValue(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, converter);
+        }
+
+        /**
+         * Sets the value converter.
+         *
+         * @param converter
+         *            the value converter class.
+         * @return this
+         */
+        public Setter valueConverter(final Class<? extends Converter> converter) {
+            return setValue(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, converter);
+        }
+
+        /**
+         * Sets the header converter.
+         *
+         * @param header
+         *            the header converter class.
+         * @return this.
+         */
+        public Setter headerConverter(final Class<? extends Converter> header) {
+            return setValue(ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG, header);
+        }
+
+        /**
+         * Sets the offset commit flush interval.
+         *
+         * @param interval
+         *            the interval between flushes.
+         * @return this.
+         */
+        public Setter offsetFlushInterval(final Duration interval) {
+            return setValue(WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG, interval.toMillis());
+        }
+
+        /**
+         * Sets the offset commit timeout.
+         *
+         * @param interval
+         *            the interval between commit timeouts.
+         * @return this.
+         */
+        public Setter offsetTimeout(final Duration interval) {
+            return setValue(WorkerConfig.OFFSET_COMMIT_TIMEOUT_MS_CONFIG, interval.toMillis());
+        }
+
+        /**
+         * Globally unique name to use for this connector.
+         *
+         * @param name
+         *            Globally unique name to use for this connector.
+         * @return this
+         */
+        public Setter name(final String name) {
+            return setValue(ConnectorConfig.NAME_CONFIG, name);
+        }
+
+        /**
+         * Sets the plugin discovery strategy.
+         *
+         * @param pluginDiscovery
+         *            the plugin discovery strategy.
+         * @return this
+         */
+        public Setter pluginDiscovery(final PluginDiscovery pluginDiscovery) {
+            return setValue(PLUGIN_DISCOVERY, pluginDiscovery.name());
+        }
+
+        /**
+         * Sets the maximum number of tasks for the connector.
+         *
+         * @param tasksMax
+         *            the maximum number of tasks.
+         * @return this
+         */
+        public Setter tasksMax(final int tasksMax) {
+            return setValue(ConnectorConfig.TASKS_MAX_CONFIG, tasksMax);
+        }
+
+        /**
+         * Sets the list of transforms
+         *
+         * @param transforms
+         *            a comma separated list of transforms.
+         * @return this
+         */
+        public Setter transforms(final String transforms) {
+            return setValue(ConnectorConfig.TRANSFORMS_CONFIG, transforms);
+        }
+
+        /**
+         * Sets the bootstrap servers.
+         *
+         * @param bootstrapServers
+         *            the bootstrap servers.
+         * @return this
+         */
+        public Setter bootstrapServers(final String bootstrapServers) {
+            return setValue(WorkerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        }
+
+        /**
+         * Sets the task shutdown timeout.
+         *
+         * @param timeout
+         *            the timeout.
+         * @return this
+         */
+        public Setter taskShutdownTimeout(final Duration timeout) {
+            return setValue(WorkerConfig.TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_CONFIG, timeout.toMillis());
+        }
+
+        /**
+         * Sets the configuration listeners.
+         *
+         * @param listeners
+         *            a comma separated string of configuration listeners.
+         * @return this
+         */
+        public Setter listeners(final String listeners) {
+            return setValue(WorkerConfig.LISTENERS_CONFIG, listeners);
+        }
+
+        /**
+         * Sets the configuration listeners.
+         *
+         * @param listeners
+         *            an array of configuration listeners.
+         * @return this
+         */
+        public Setter listeners(final String... listeners) {
+            return setValue(WorkerConfig.LISTENERS_CONFIG, String.join(", ", listeners));
+        }
+
+        /**
+         * Sets the advertised host name.
+         *
+         * @param hostName
+         *            the advertised host name
+         * @return this
+         */
+        public Setter advertisedHostName(final String hostName) {
+            return setValue(WorkerConfig.REST_ADVERTISED_HOST_NAME_CONFIG, hostName);
+        }
+
+        /**
+         * Sets the advertised host port.
+         *
+         * @param port
+         *            the advertised host port.
+         * @return
+         */
+        public Setter advertisedHostPort(final int port) {
+            return setValue(WorkerConfig.REST_ADVERTISED_PORT_CONFIG, port);
+        }
+
+        /**
+         * Sets the advertised listener protocol.
+         *
+         * @param protocol
+         *            HTTP or HTTPS
+         * @return this
+         */
+        public Setter advertisedListenerProtocol(final String protocol) {
+            return setValue(WorkerConfig.REST_ADVERTISED_LISTENER_CONFIG, protocol);
+        }
+
+        /**
+         * Sets the aAccess-Control-Allow-Origin header to for REST API requests. To enable cross-origin access, set
+         * this to the domain of the application that should be permitted to access the API, or '*' to allow access from
+         * any domain. The default value only allows access from the domain of the REST API.
+         *
+         * @param origin
+         *            the orgin to allow
+         * @return this
+         */
+        public Setter accessControlAllowOrigin(final String origin) {
+            return setValue(WorkerConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, origin);
+        }
+
+        /**
+         * Sets the methods supported for cross origin requests by setting the Access-Control-Allow-Methods header. The
+         * default value of the Access-Control-Allow-Methods header allows cross-origin requests for GET, POST and HEAD.
+         *
+         * @param methods
+         *            A list of methods to allow.
+         * @return this
+         */
+        public Setter accessControlAllowMethods(final String methods) {
+            return setValue(WorkerConfig.ACCESS_CONTROL_ALLOW_METHODS_CONFIG, methods);
+        }
+
+        /**
+         * Sets the list of paths separated by commas (,) that contain plugins (connectors, converters,
+         * transformations). Example: "/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/connectors"
+         *
+         * @param pluginPath
+         *            the list of paths.
+         * @return this
+         * @see #pluginPath(String...)
+         */
+        public Setter pluginPath(final String pluginPath) {
+            return setValue(WorkerConfig.PLUGIN_PATH_CONFIG, pluginPath);
+        }
+
+        /**
+         * Sets the list of paths that contain plugins (connectors, converters, transformations). The list should
+         * consist of top level directories that include any combination of:
+         * <ul>
+         * <li>directories immediately containing jars with plugins and their dependencies</li>
+         * <li>uber-jars with plugins and their dependencies</li>
+         * <li>directories immediately containing the package directory structure of classes of plugins and their
+         * dependencies</li>
+         * </ul>
+         * <p>
+         * Note: symlinks will be followed to discover dependencies or plugins.
+         * </p>
+         *
+         * @param pluginPath
+         *            the list of paths to to search,.
+         * @return this.
+         */
+        public Setter pluginPath(final String... pluginPath) {
+            return setValue(WorkerConfig.PLUGIN_PATH_CONFIG, String.join(", ", pluginPath));
+        }
+
+        /**
+         * Sets the metrics sample window size.
+         *
+         * @param window
+         *            the time for each window.
+         * @return this
+         */
+        public Setter metricsSampleWindow(final Duration window) {
+            return setValue(WorkerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG, window.toMillis());
+        }
+
+        /**
+         * The number of samples maintained to compute metrics.
+         *
+         * @param count
+         *            the number of samples.
+         * @return this.
+         */
+        public Setter metricsSampleCount(final int count) {
+            return setValue(WorkerConfig.METRICS_NUM_SAMPLES_CONFIG, count);
+        }
+
+        /**
+         * The highest recording level for metrics.
+         *
+         * @param level
+         *            the recording level
+         * @return this.
+         */
+        public Setter metricsRecordingLevel(final int level) {
+            return setValue(WorkerConfig.METRICS_RECORDING_LEVEL_CONFIG, level);
+        }
+
+        /**
+         * A list of classes to use as metrics reporters. Implementing the
+         * {@link org.apache.kafka.common.metrics.MetricsReporter} interface allows plugging in classes that will be
+         * notified of new metric creation. The JmxReporter is always included to register JMX statistics.
+         *
+         * @param reporterClasses
+         *            the classes to use.
+         * @return this
+         */
+        public Setter metricReporterClasses(final Class<? extends MetricsReporter>... reporterClasses) {
+            return setValue(WorkerConfig.METRIC_REPORTER_CLASSES_CONFIG,
+                    Arrays.stream(reporterClasses).map(Class::getName).collect(Collectors.joining(", ")));
+        }
+    }
+}

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/OutputFormatFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/OutputFormatFragment.java
@@ -17,6 +17,7 @@
 package io.aiven.kafka.connect.common.config;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -52,8 +53,14 @@ public final class OutputFormatFragment extends ConfigFragment {
     public static ConfigDef update(final ConfigDef configDef, final OutputFieldType defaultFieldType) {
         int formatGroupCounter = 0;
 
+        final String supportedFormatTypes = FormatType.names()
+                .stream()
+                .map(f -> "'" + f + "'")
+                .collect(Collectors.joining(", "));
+
         configDef.define(FORMAT_OUTPUT_TYPE_CONFIG, ConfigDef.Type.STRING, FormatType.CSV.name,
-                new OutputTypeValidator(), ConfigDef.Importance.MEDIUM, "The format type of output content.",
+                new OutputTypeValidator(), ConfigDef.Importance.MEDIUM,
+                "The format type of output content" + "The supported values are: " + supportedFormatTypes + ".",
                 GROUP_FORMAT, 0, ConfigDef.Width.NONE, FORMAT_OUTPUT_TYPE_CONFIG,
                 FixedSetRecommender.ofSupportedValues(FormatType.names()));
 
@@ -78,6 +85,17 @@ public final class OutputFormatFragment extends ConfigFragment {
         return configDef;
     }
 
+    /**
+     * Creates a setter for this fragment
+     *
+     * @param data
+     *            the data to update
+     * @return the Setter.
+     */
+    public static Setter setter(final Map<String, String> data) {
+        return new Setter(data);
+    }
+
     @Override
     public void validate() {
         // Special checks for output json envelope config.
@@ -89,14 +107,34 @@ public final class OutputFormatFragment extends ConfigFragment {
             throw new ConfigException(msg);
         }
     }
+
+    /**
+     * Gets the defined format type.
+     *
+     * @return the FormatType.
+     */
     public FormatType getFormatType() {
         return FormatType.forName(cfg.getString(FORMAT_OUTPUT_TYPE_CONFIG));
     }
 
+    public boolean hasFormatType() {
+        return has(FORMAT_OUTPUT_TYPE_CONFIG);
+    }
+
+    /**
+     * Gets the envelope enabled state.
+     *
+     * @return the envelope enabled state.
+     */
     public Boolean envelopeEnabled() {
         return cfg.getBoolean(FORMAT_OUTPUT_ENVELOPE_CONFIG);
     }
 
+    /**
+     * Gets the output field encoding type.
+     *
+     * @return the Output field encodging type.
+     */
     public OutputFieldEncodingType getOutputFieldEncodingType() {
         return OutputFieldEncodingType.forName(cfg.getString(FORMAT_OUTPUT_FIELDS_VALUE_ENCODING_CONFIG));
     }
@@ -131,10 +169,82 @@ public final class OutputFormatFragment extends ConfigFragment {
         final List<String> fields = cfg.getList(configEntry);
         return fields.stream().map(fieldName -> {
             final var type = OutputFieldType.forName(fieldName);
-            final var encoding = type == OutputFieldType.KEY || type == OutputFieldType.VALUE
+            final var encoding = type == OutputFieldType.VALUE
                     ? getOutputFieldEncodingType()
                     : OutputFieldEncodingType.NONE;
             return new OutputField(type, encoding);
         }).collect(Collectors.toUnmodifiableList());
+    }
+
+    /**
+     * The setter for OutputFormatFragment.
+     */
+    public static class Setter extends AbstractFragmentSetter<Setter> {
+
+        /**
+         * Constructor.
+         *
+         * @param data
+         *            the map of data items being set.
+         */
+        private Setter(final Map<String, String> data) {
+            super(data);
+        }
+
+        /**
+         * Sets the format type.
+         *
+         * @param formatType
+         *            the format type.
+         * @return this
+         */
+        public Setter withFormatType(final FormatType formatType) {
+            return setValue(FORMAT_OUTPUT_TYPE_CONFIG, formatType.name());
+        }
+
+        /**
+         * Sets the output field encoding type.
+         *
+         * @param encodingType
+         *            the output field encoding type.
+         * @return this
+         */
+        public Setter withOutputFieldEncodingType(final OutputFieldEncodingType encodingType) {
+            return setValue(FORMAT_OUTPUT_FIELDS_VALUE_ENCODING_CONFIG, encodingType.name());
+        }
+
+        /**
+         * Sets the list of output fields.
+         *
+         * @param outputFields
+         *            the list of output fields
+         * @return this
+         */
+        public Setter withOutputFields(final List<OutputFieldType> outputFields) {
+            return setValue(FORMAT_OUTPUT_FIELDS_CONFIG,
+                    outputFields.stream().map(OutputFieldType::toString).collect(Collectors.joining(",")));
+        }
+
+        /**
+         * Sets the list of output fields.
+         *
+         * @param outputFields
+         *            the list of output fields
+         * @return this
+         */
+        public Setter withOutputFields(final OutputFieldType... outputFields) {
+            return withOutputFields(List.of(outputFields));
+        }
+
+        /**
+         * Sets the envelope enabled flag.
+         *
+         * @param envelopeEnabled
+         *            the desired flag state.
+         * @return this
+         */
+        public Setter envelopeEnabled(final boolean envelopeEnabled) {
+            return setValue(FORMAT_OUTPUT_ENVELOPE_CONFIG, envelopeEnabled);
+        }
     }
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/OutputFormatFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/OutputFormatFragment.java
@@ -169,7 +169,7 @@ public final class OutputFormatFragment extends ConfigFragment {
         final List<String> fields = cfg.getList(configEntry);
         return fields.stream().map(fieldName -> {
             final var type = OutputFieldType.forName(fieldName);
-            final var encoding = type == OutputFieldType.VALUE
+            final var encoding = type == OutputFieldType.KEY || type == OutputFieldType.VALUE
                     ? getOutputFieldEncodingType()
                     : OutputFieldEncodingType.NONE;
             return new OutputField(type, encoding);

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
@@ -38,7 +38,6 @@ public class SourceCommonConfig extends CommonConfig {
         transformerFragment = new TransformerFragment(this);
         sourceConfigFragment = new SourceConfigFragment(this);
         fileNameFragment = new FileNameFragment(this);
-
         validate(); // NOPMD ConstructorCallsOverridableMethod
     }
 
@@ -81,7 +80,6 @@ public class SourceCommonConfig extends CommonConfig {
     }
 
     public String getSourceName() {
-        return sourceConfigFragment.getSourceName();
+        return fileNameFragment.getSourceName();
     }
-
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/TransformerFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/TransformerFragment.java
@@ -18,6 +18,7 @@ package io.aiven.kafka.connect.common.config;
 
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.AbstractConfig;
@@ -26,6 +27,9 @@ import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.connect.common.source.input.InputFormat;
 
+/**
+ * Fragment to manage transformer configuration.
+ */
 public final class TransformerFragment extends ConfigFragment {
     private static final String TRANSFORMER_GROUP = "Transformer group";
     public static final String SCHEMA_REGISTRY_URL = "schema.registry.url";
@@ -37,7 +41,18 @@ public final class TransformerFragment extends ConfigFragment {
     private static final int DEFAULT_MAX_BUFFER_SIZE = 4096;
 
     /**
-     * Construct the ConfigFragment..
+     * Creates a Setter for this fragment.
+     *
+     * @param data
+     *            the data map to modify.
+     * @return the Setter
+     */
+    public static Setter setter(final Map<String, String> data) {
+        return new Setter(data);
+    }
+
+    /**
+     * Construct the ConfigFragment.
      *
      * @param cfg
      *            the configuration that this fragment is associated with.
@@ -46,40 +61,55 @@ public final class TransformerFragment extends ConfigFragment {
         super(cfg);
     }
 
+    /**
+     * Update the configuration definition with the properties for this fragment.
+     *
+     * @param configDef
+     *            the configuration definition to update.
+     * @return the updated configuration definition.
+     */
     public static ConfigDef update(final ConfigDef configDef) {
         int transformerCounter = 0;
         configDef.define(SCHEMA_REGISTRY_URL, ConfigDef.Type.STRING, null, new ConfigDef.NonEmptyString(),
-                ConfigDef.Importance.MEDIUM, "SCHEMA REGISTRY URL", TRANSFORMER_GROUP, transformerCounter++,
+                ConfigDef.Importance.MEDIUM, "SCHEMA REGISTRY URL", TRANSFORMER_GROUP, ++transformerCounter,
                 ConfigDef.Width.NONE, SCHEMA_REGISTRY_URL);
         configDef.define(VALUE_CONVERTER_SCHEMA_REGISTRY_URL, ConfigDef.Type.STRING, null,
                 new ConfigDef.NonEmptyString(), ConfigDef.Importance.MEDIUM, "SCHEMA REGISTRY URL", TRANSFORMER_GROUP,
-                transformerCounter++, ConfigDef.Width.NONE, VALUE_CONVERTER_SCHEMA_REGISTRY_URL);
+                ++transformerCounter, ConfigDef.Width.NONE, VALUE_CONVERTER_SCHEMA_REGISTRY_URL);
         configDef.define(INPUT_FORMAT_KEY, ConfigDef.Type.STRING, InputFormat.BYTES.getValue(),
                 new InputFormatValidator(), ConfigDef.Importance.MEDIUM, "Input format of messages read from source",
                 TRANSFORMER_GROUP, transformerCounter++, ConfigDef.Width.NONE, INPUT_FORMAT_KEY);
         configDef.define(TRANSFORMER_MAX_BUFFER_SIZE, ConfigDef.Type.INT, DEFAULT_MAX_BUFFER_SIZE,
                 ConfigDef.Range.between(1, Integer.MAX_VALUE), ConfigDef.Importance.MEDIUM,
-                "Max Size of the byte buffer when using the BYTE Transformer", TRANSFORMER_GROUP, transformerCounter++,
+                "Max Size of the byte buffer when using the BYTE Transformer", TRANSFORMER_GROUP, ++transformerCounter,
                 ConfigDef.Width.NONE, TRANSFORMER_MAX_BUFFER_SIZE);
-        configDef.define(AVRO_VALUE_SERIALIZER, ConfigDef.Type.CLASS, null, ConfigDef.Importance.MEDIUM,
-                "Avro value serializer", TRANSFORMER_GROUP, transformerCounter++, // NOPMD
-                // UnusedAssignment
-                ConfigDef.Width.NONE, AVRO_VALUE_SERIALIZER);
+
         return configDef;
     }
 
+    /**
+     * Gets the input format for the transformer.
+     *
+     * @return the Input format for the
+     */
     public InputFormat getInputFormat() {
         return InputFormat.valueOf(cfg.getString(INPUT_FORMAT_KEY).toUpperCase(Locale.ROOT));
     }
 
+    /**
+     * Get the schema registry URL.
+     *
+     * @return the schema registry URL
+     */
     public String getSchemaRegistryUrl() {
         return cfg.getString(SCHEMA_REGISTRY_URL);
     }
 
-    public Class<?> getAvroValueSerializer() {
-        return cfg.getClass(AVRO_VALUE_SERIALIZER);
-    }
-
+    /**
+     * Gets the maximum buffer size for the BYTE input.
+     *
+     * @return the maximum buffer size fo the BYTE input.
+     */
     public int getTransformerMaxBufferSize() {
         return cfg.getInt(TRANSFORMER_MAX_BUFFER_SIZE);
     }
@@ -102,6 +132,64 @@ public final class TransformerFragment extends ConfigFragment {
             return Arrays.stream(InputFormat.values())
                     .map(f -> "'" + f.getValue() + "'")
                     .collect(Collectors.joining(", "));
+        }
+    }
+    /**
+     * The setter for the TransformerFragment
+     */
+    public final static class Setter extends AbstractFragmentSetter<Setter> {
+        /**
+         * Constructor.
+         *
+         * @param data
+         *            data to modify.
+         */
+        private Setter(final Map<String, String> data) {
+            super(data);
+        }
+
+        /**
+         * Sets the schema registry URL.
+         *
+         * @param schemaRegistryUrl
+         *            the schema registry URL.
+         * @return this
+         */
+        public Setter schemaRegistry(final String schemaRegistryUrl) {
+            return setValue(SCHEMA_REGISTRY_URL, schemaRegistryUrl);
+        }
+
+        /**
+         * Sets the schema registry for the value converter schema registry URL.
+         *
+         * @param valueConverterSchemaRegistryUrl
+         *            the schema registry URL.
+         * @return this
+         */
+        public Setter valueConverterSchemaRegistry(final String valueConverterSchemaRegistryUrl) {
+            return setValue(VALUE_CONVERTER_SCHEMA_REGISTRY_URL, valueConverterSchemaRegistryUrl);
+        }
+
+        /**
+         * Sets the input format.
+         *
+         * @param inputFormat
+         *            the input format for the transformer.
+         * @return this
+         */
+        public Setter inputFormat(final InputFormat inputFormat) {
+            return setValue(INPUT_FORMAT_KEY, inputFormat.name());
+        }
+
+        /**
+         * Sets the max buffer size for a BYTE transformer.
+         *
+         * @param maxBufferSize
+         *            the maximum buffer size.
+         * @return this
+         */
+        public Setter maxBufferSize(final int maxBufferSize) {
+            return setValue(TRANSFORMER_MAX_BUFFER_SIZE, maxBufferSize);
         }
     }
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/FileCompressionTypeValidator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/FileCompressionTypeValidator.java
@@ -31,8 +31,8 @@ public class FileCompressionTypeValidator implements ConfigDef.Validator {
         // is it up to the connector decide how to support default values for compression.
         // The reason is that for different connectors there is the different compression type
         if (Objects.nonNull(value)) {
-            final String valueStr = (String) value;
-            if (!CompressionType.names().contains(valueStr.toLowerCase(Locale.ROOT))) {
+            final String valueStr = value.toString().toLowerCase(Locale.ROOT);
+            if (!CompressionType.names().contains(valueStr)) {
                 throw new ConfigException(name, valueStr, toString());
             }
         }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/FilenameTemplateValidator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/FilenameTemplateValidator.java
@@ -39,6 +39,10 @@ import io.aiven.kafka.connect.common.templating.VariableTemplatePart.Parameter;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+/**
+ * @deprecated switch to {@link SourcenameTemplateValidator} and specific sink/source validation.
+ */
+@Deprecated
 public final class FilenameTemplateValidator implements ConfigDef.Validator {
 
     static final Map<String, ParameterDescriptor> SUPPORTED_VARIABLE_PARAMETERS = new LinkedHashMap<>();

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/OutputTypeValidator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/OutputTypeValidator.java
@@ -16,27 +16,33 @@
 
 package io.aiven.kafka.connect.common.config.validators;
 
-import java.util.Objects;
+import java.util.Locale;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import io.aiven.kafka.connect.common.config.FormatType;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class OutputTypeValidator implements ConfigDef.Validator {
 
     @Override
     public void ensureValid(final String name, final Object value) {
-        if (Objects.nonNull(value)) {
-            final String valueStr = (String) value;
-            if (!FormatType.names().contains(valueStr)) {
-                throw new ConfigException(name, valueStr, toString());
-            }
+        final String valueStr = value == null ? null : value.toString();
+        if (StringUtils.isBlank(valueStr)) {
+            throw new ConfigException(name, "must not be empty or not set");
+        }
+        try {
+            FormatType.valueOf(valueStr.toUpperCase(Locale.ROOT));
+        } catch (final IllegalArgumentException e) {
+            throw new ConfigException(name, valueStr, "Supported values are: " + this);
         }
     }
 
     @Override
     public String toString() {
-        return "Supported values are: " + FormatType.SUPPORTED_FORMAT_TYPES;
+        return FormatType.names().stream().map(s -> "'" + s + "'").collect(Collectors.joining(", "));
     }
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidator.java
@@ -23,9 +23,13 @@ import static io.aiven.kafka.connect.common.config.FilenameTemplateVariable.TIME
 import static io.aiven.kafka.connect.common.config.FilenameTemplateVariable.TOPIC;
 import static io.aiven.kafka.connect.common.grouper.RecordGrouperFactory.ALL_SUPPORTED_VARIABLES;
 
-import java.util.LinkedHashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
@@ -37,8 +41,8 @@ import org.apache.commons.lang3.StringUtils;
 
 public final class SourcenameTemplateValidator implements ConfigDef.Validator {
 
-    static final Map<String, ParameterDescriptor> SUPPORTED_VARIABLE_PARAMETERS = new LinkedHashMap<>();
-    static final Map<String, ParameterDescriptor> REQUIRED_VARIABLE_PARAMETERS = new LinkedHashMap<>();
+    static final Map<String, ParameterDescriptor> SUPPORTED_VARIABLE_PARAMETERS = new TreeMap<>();
+    static final Map<String, ParameterDescriptor> REQUIRED_VARIABLE_PARAMETERS = new TreeMap<>();
 
     static {
         REQUIRED_VARIABLE_PARAMETERS.put(PARTITION.name, PARTITION.parameterDescriptor);
@@ -48,61 +52,68 @@ public final class SourcenameTemplateValidator implements ConfigDef.Validator {
         SUPPORTED_VARIABLE_PARAMETERS.put(TOPIC.name, TOPIC.parameterDescriptor);
     }
 
-    private final String configName;
     private final DistributionType distributionType;
 
-    public SourcenameTemplateValidator(final String configName, final DistributionType distributionType) {
-        this.configName = configName;
+    public SourcenameTemplateValidator(final DistributionType distributionType) {
         this.distributionType = distributionType;
     }
 
     @Override
     public void ensureValid(final String name, final Object value) {
-        if (value == null) {
-            return;
+        final String valueStr = value == null ? null : value.toString();
+        if (StringUtils.isBlank(valueStr)) {
+            throw new ConfigException(name, "must not be empty or not set");
         }
-
-        assert value instanceof String;
-
         // See https://cloud.google.com/storage/docs/naming
-        final String valueStr = (String) value;
         if (valueStr.startsWith(".well-known/acme-challenge")) {
-            throw new ConfigException(configName, value, "cannot start with '.well-known/acme-challenge'");
+            throw new ConfigException(name, value, "cannot start with '.well-known/acme-challenge'");
         }
 
-        if (StringUtils.isNotBlank(valueStr) && distributionType.equals(DistributionType.OBJECT_HASH)) {
-            // accepts any string or regex to match on.
-            return;
-        } else if (StringUtils.isBlank(valueStr)) {
-            throw new ConfigException(configName, "Can not be a blank or empty string");
-        }
-        // if using partition distribution it requires the partition to be available.
-        try {
-            final Template template = Template.of((String) value);
-            validateVariables(template.variablesSet());
-            validateVariablesWithRequiredParameters(template.toString());
-        } catch (final IllegalArgumentException e) {
-            throw new ConfigException(configName, value, e.getMessage());
-        }
-    }
-
-    private static void validateVariables(final Set<String> variables) {
-        for (final String variable : variables) {
-            if (!ALL_SUPPORTED_VARIABLES.contains(variable)) {
-                throw new IllegalArgumentException(
-                        String.format("unsupported template variable used, supported values are: %s",
-                                SUPPORTED_VARIABLE_PARAMETERS.keySet()));
+        // TODO when distributionType expands then add required parameters to each distribution type object
+        // and change this to a switch statement
+        if (distributionType.equals(DistributionType.PARTITION)) {
+            // partition distribution requires the partition to be available.
+            try {
+                final Template template = Template.of((String) value);
+                validateVariables(template.variablesSet());
+                validateVariablesWithRequiredParameters(template.toString());
+            } catch (final IllegalArgumentException e) {
+                throw new ConfigException(name, value, e.getMessage());
             }
         }
     }
 
-    public static void validateVariablesWithRequiredParameters(final String sourceNameTemplate) {
+    private String formatVariable(final String variableName) {
+        return "{{" + variableName + "}}";
+    }
+
+    private String formatVariables(final Collection<String> variables) {
+        return variables.stream().map(this::formatVariable).collect(Collectors.joining(", "));
+    }
+
+    private void validateVariables(final Set<String> variables) {
+        final List<String> invalidVariables = new ArrayList<>(variables);
+        invalidVariables.removeAll(ALL_SUPPORTED_VARIABLES);
+        if (!invalidVariables.isEmpty()) {
+            final String variableText = invalidVariables.size() == 1 ? "variable" : "variables";
+            throw new IllegalArgumentException(String.format(
+                    "unsupported template %s used (%s), supported values are: %s", variableText,
+                    formatVariables(invalidVariables), formatVariables(SUPPORTED_VARIABLE_PARAMETERS.keySet())));
+        }
+    }
+
+    private void validateVariablesWithRequiredParameters(final String sourceNameTemplate) {
+        final List<String> missingVariables = new ArrayList<>();
         for (final String requiredVariableParameter : REQUIRED_VARIABLE_PARAMETERS.keySet()) {
             if (!sourceNameTemplate.contains(requiredVariableParameter)) {
-                throw new IllegalArgumentException(String
-                        .format("parameter %s is required for the the file.name.template", requiredVariableParameter));
+                missingVariables.add(requiredVariableParameter);
             }
         }
-
+        if (!missingVariables.isEmpty()) {
+            final String parameterText = missingVariables.size() == 1 ? "parameter" : "parameters";
+            throw new IllegalArgumentException(
+                    String.format("Partition distribution type requires %s %s in the file.name.template", parameterText,
+                            formatVariables(missingVariables)));
+        }
     }
 }

--- a/commons/src/test/java/io/aiven/kafka/connect/common/config/FileNameFragmentTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/config/FileNameFragmentTest.java
@@ -19,6 +19,7 @@ package io.aiven.kafka.connect.common.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.lang.reflect.Modifier;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,37 +40,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class FileNameFragmentTest {// NOPMD
 
-    /**
-     * An enumeration to expose the FileNameFragment properties names to test cases
-     */
-    public enum FileNameArgs {
-        GROUP_FILE(FileNameFragment.GROUP_FILE), FILE_COMPRESSION_TYPE_CONFIG(
-                FileNameFragment.FILE_COMPRESSION_TYPE_CONFIG), FILE_MAX_RECORDS(
-                        FileNameFragment.FILE_MAX_RECORDS), FILE_NAME_TIMESTAMP_TIMEZONE(
-                                FileNameFragment.FILE_NAME_TIMESTAMP_TIMEZONE), FILE_NAME_TIMESTAMP_SOURCE(
-                                        FileNameFragment.FILE_NAME_TIMESTAMP_SOURCE), FILE_NAME_TEMPLATE_CONFIG(
-                                                FileNameFragment.FILE_NAME_TEMPLATE_CONFIG), DEFAULT_FILENAME_TEMPLATE(
-                                                        FileNameFragment.DEFAULT_FILENAME_TEMPLATE);
-        private final String keyValue;
-
-        FileNameArgs(final String key) {
-            this.keyValue = key;
-        }
-
-        public String key() {
-            return keyValue;
-        }
-    }
-
     @ParameterizedTest(name = "{index} {0}")
     @MethodSource("configDefSource")
-    void configDefTest(final FileNameArgs arg, final ConfigDef.Type type, final Object defaultValue,
-            final boolean validatorPresent, final ConfigDef.Importance importance, final String group,
-            final int orderInGroup, final ConfigDef.Width width, final boolean recommenderPresent) {
+    void configDefTest(final String arg, final ConfigDef.Type type, final Object defaultValue,
+            final boolean validatorPresent, final ConfigDef.Importance importance, final boolean recommenderPresent) {
         final ConfigDef configDef = FileNameFragment.update(new ConfigDef());
-        final ConfigDef.ConfigKey key = configDef.configKeys().get(arg.key());
+        final ConfigDef.ConfigKey key = configDef.configKeys().get(arg);
 
-        assertThat(arg.key()).as("Wrong key name").isEqualTo(key.name);
+        assertThat(arg).as("Wrong key name").isEqualTo(key.name);
         assertThat(type).as("Wrong key type").isEqualTo(key.type);
         assertThat(defaultValue).as("Wrong default value").isEqualTo(key.defaultValue);
         assertThat(validatorPresent)
@@ -77,9 +55,6 @@ public class FileNameFragmentTest {// NOPMD
                 .isEqualTo(key.validator != null);
         assertThat(importance).as("Wrong importance").isEqualTo(key.importance);
         assertThat(key.documentation).as("Documenttion not included").isNotNull();
-        assertThat(group).as("Wrong group").isEqualTo(key.group);
-        assertThat(orderInGroup).as("Wrong order in group").isEqualTo(key.orderInGroup);
-        assertThat(width).as("Wrong width").isEqualTo(key.width);
         assertThat(key.name).isEqualTo(key.displayName);
         assertThat(recommenderPresent)
                 .as(() -> String.format("Recommender was %spresent.", key.recommender == null ? "not " : ""))
@@ -88,37 +63,43 @@ public class FileNameFragmentTest {// NOPMD
 
     @Test
     void allConfigDefsAccountForTest() {
-        // create a modifiable list.
-        final List<FileNameArgs> argList = new ArrayList<>(Arrays.asList(FileNameArgs.values()));
-        // remove the non-argument values
-        argList.remove(FileNameArgs.GROUP_FILE);
-        argList.remove(FileNameArgs.DEFAULT_FILENAME_TEMPLATE);
-        configDefSource().map(a -> (FileNameArgs) (a.get()[0])).forEach(argList::remove);
-        assertThat(argList.isEmpty())
-                .as(() -> "Tests do not process the following arguments: "
-                        + String.join(", ", argList.stream().map(arg -> arg.toString()).collect(Collectors.toList())))
+        final List<String> names = Arrays.stream(FileNameFragment.class.getDeclaredFields())
+                .filter(field -> Modifier.isStatic(field.getModifiers()) && field.getType().equals(String.class))
+                .map(field -> {
+                    try {
+                        return field.get(null).toString();
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e); // NOPMD
+                    }
+                })
+                .collect(Collectors.toList());
+        names.remove(FileNameFragment.GROUP_FILE);
+        names.remove(FileNameFragment.DEFAULT_FILENAME_TEMPLATE);
+        // TODO remove this when we understand what it is for.
+        names.remove(FileNameFragment.FILE_PATH_PREFIX_TEMPLATE_CONFIG);
+        configDefSource().map(a -> (String) (a.get()[0])).forEach(names::remove);
+        assertThat(names.isEmpty())
+                .as(() -> "Tests do not process the following arguments: " + String.join(", ", names))
                 .isTrue();
     }
 
     private static Stream<Arguments> configDefSource() {
         final List<Arguments> args = new ArrayList<>();
 
-        args.add(Arguments.of(FileNameArgs.FILE_NAME_TEMPLATE_CONFIG, ConfigDef.Type.STRING, null, true,
-                ConfigDef.Importance.MEDIUM, FileNameArgs.GROUP_FILE.key(), 0, ConfigDef.Width.LONG, false));
+        args.add(Arguments.of(FileNameFragment.FILE_NAME_TEMPLATE_CONFIG, ConfigDef.Type.STRING, null, false,
+                ConfigDef.Importance.MEDIUM, false));
 
-        args.add(Arguments.of(FileNameArgs.FILE_COMPRESSION_TYPE_CONFIG, ConfigDef.Type.STRING, null, true,
-                ConfigDef.Importance.MEDIUM, FileNameArgs.GROUP_FILE.key(), 1, ConfigDef.Width.NONE, true));
+        args.add(Arguments.of(FileNameFragment.FILE_COMPRESSION_TYPE_CONFIG, ConfigDef.Type.STRING, null, true,
+                ConfigDef.Importance.MEDIUM, true));
 
-        args.add(Arguments.of(FileNameArgs.FILE_MAX_RECORDS, ConfigDef.Type.INT, 0, true, ConfigDef.Importance.MEDIUM,
-                FileNameArgs.GROUP_FILE.key(), 2, ConfigDef.Width.SHORT, false));
+        args.add(Arguments.of(FileNameFragment.FILE_MAX_RECORDS, ConfigDef.Type.INT, 0, true,
+                ConfigDef.Importance.MEDIUM, false));
 
-        args.add(Arguments.of(FileNameArgs.FILE_NAME_TIMESTAMP_TIMEZONE, ConfigDef.Type.STRING,
-                ZoneOffset.UTC.toString(), true, ConfigDef.Importance.LOW, FileNameArgs.GROUP_FILE.key(), 3,
-                ConfigDef.Width.SHORT, false));
+        args.add(Arguments.of(FileNameFragment.FILE_NAME_TIMESTAMP_TIMEZONE, ConfigDef.Type.STRING,
+                ZoneOffset.UTC.toString(), true, ConfigDef.Importance.LOW, false));
 
-        args.add(Arguments.of(FileNameArgs.FILE_NAME_TIMESTAMP_SOURCE, ConfigDef.Type.STRING,
-                TimestampSource.Type.WALLCLOCK.name(), true, ConfigDef.Importance.LOW, FileNameArgs.GROUP_FILE.key(), 4,
-                ConfigDef.Width.SHORT, false));
+        args.add(Arguments.of(FileNameFragment.FILE_NAME_TIMESTAMP_SOURCE, ConfigDef.Type.STRING,
+                TimestampSource.Type.WALLCLOCK.name(), true, ConfigDef.Importance.LOW, false));
 
         return args.stream();
     }
@@ -237,7 +218,5 @@ public class FileNameFragmentTest {// NOPMD
 
         props.put(FileNameFragment.FILE_MAX_RECORDS, "-1");
         assertThatThrownBy(() -> new AbstractConfig(configDef, props)).isInstanceOf(ConfigException.class);
-
     }
-
 }

--- a/commons/src/test/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidatorTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/config/validators/SourcenameTemplateValidatorTest.java
@@ -33,39 +33,30 @@ class SourcenameTemplateValidatorTest {
     @CsvSource({ "{{topic}}-{{partition}}-{{start_offset}}.avro,partition", "*-{{partition}}.parquet,partition",
             "*.gz,object_hash", "'([a-zA-Z0-9_-]{3,5}.gz',object_hash" })
     void validateBasicSourceNamesPass(final String sourceName, final String distributionType) {
-        assertThatCode(
-                () -> new SourcenameTemplateValidator(TEST_CONFIG_NAME, DistributionType.forName(distributionType))
-                        .ensureValid(null, sourceName))
-                .doesNotThrowAnyException();
+        assertThatCode(() -> new SourcenameTemplateValidator(DistributionType.forName(distributionType))
+                .ensureValid(TEST_CONFIG_NAME, sourceName)).doesNotThrowAnyException();
     }
 
     @ParameterizedTest
     @CsvSource({
-            "{{topic}}-{{start_offset}}.avro,partition,'Invalid value {{topic}}-{{start_offset}}.avro for configuration TEST_CONFIG: parameter partition is required for the the file.name.template'",
-            "*.parquet,partition,'Invalid value *.parquet for configuration TEST_CONFIG: parameter partition is required for the the file.name.template'",
-            "' ',object_hash,'Invalid value Can not be a blank or empty string for configuration TEST_CONFIG'" })
+            "{{topic}}-{{start_offset}}.avro, partition,'Invalid value {{topic}}-{{start_offset}}.avro for configuration TEST_CONFIG: Partition distribution type requires parameter {{partition}} in the file.name.template'",
+            "*.parquet, partition,'Invalid value *.parquet for configuration TEST_CONFIG: Partition distribution type requires parameter {{partition}} in the file.name.template'",
+            "' ', object_hash,'Invalid value must not be empty or not set for configuration TEST_CONFIG'" })
     void validateVariableWithInvalidParameterName(final String sourceName, final String distributionType,
             final String message) {
 
-        assertThatThrownBy(
-                () -> new SourcenameTemplateValidator(TEST_CONFIG_NAME, DistributionType.forName(distributionType))
-                        .ensureValid(null, sourceName))
-                .isInstanceOf(ConfigException.class)
-                .hasMessage(message);
+        assertThatThrownBy(() -> new SourcenameTemplateValidator(DistributionType.forName(distributionType))
+                .ensureValid(TEST_CONFIG_NAME, sourceName)).isInstanceOf(ConfigException.class).hasMessage(message);
     }
 
     @ParameterizedTest
     @CsvSource({
-            "{{topic}}-{{long}}.avro,partition,'Invalid value {{topic}}-{{long}}.avro for configuration TEST_CONFIG: unsupported template variable used, supported values are: [partition, start_offset, timestamp, topic]'",
-            "{{filename}}-{{partition}}.parquet,partition,'Invalid value {{filename}}-{{partition}}.parquet for configuration TEST_CONFIG: unsupported template variable used, supported values are: [partition, start_offset, timestamp, topic]'", })
+            "{{topic}}-{{long}}.avro,partition,'Invalid value {{topic}}-{{long}}.avro for configuration TEST_CONFIG: unsupported template variable used ({{long}}), supported values are: {{partition}}, {{start_offset}}, {{timestamp}}, {{topic}}'",
+            "{{filename}}-{{partition}}.parquet,partition,'Invalid value {{filename}}-{{partition}}.parquet for configuration TEST_CONFIG: unsupported template variable used ({{filename}}), supported values are: {{partition}}, {{start_offset}}, {{timestamp}}, {{topic}}'", })
     void validateCorrectExceptionsOnInvalidTemplates(final String sourceName, final String distributionType,
             final String message) {
 
-        assertThatThrownBy(
-                () -> new SourcenameTemplateValidator(TEST_CONFIG_NAME, DistributionType.forName(distributionType))
-                        .ensureValid(null, sourceName))
-                .isInstanceOf(ConfigException.class)
-                .hasMessage(message);
+        assertThatThrownBy(() -> new SourcenameTemplateValidator(DistributionType.forName(distributionType))
+                .ensureValid(TEST_CONFIG_NAME, sourceName)).isInstanceOf(ConfigException.class).hasMessage(message);
     }
-
 }

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/input/TransformerStreamingTest.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/input/TransformerStreamingTest.java
@@ -16,7 +16,6 @@
 
 package io.aiven.kafka.connect.common.source.input;
 
-import static io.aiven.kafka.connect.common.config.OutputFormatFragmentFixture.OutputFormatArgs.FORMAT_OUTPUT_TYPE_CONFIG;
 import static io.aiven.kafka.connect.common.source.input.Transformer.UNKNOWN_STREAM_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,11 +31,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.data.SchemaAndValue;
 
+import io.aiven.kafka.connect.common.config.FileNameFragment;
+import io.aiven.kafka.connect.common.config.FormatType;
 import io.aiven.kafka.connect.common.config.OutputFormatFragment;
 import io.aiven.kafka.connect.common.config.SourceCommonConfig;
 import io.aiven.kafka.connect.common.config.SourceConfigFragment;
@@ -50,7 +52,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Abstract test class to verify that streaming data is closed properly.
+ * Tests to verify that streaming data passing through a transformer is closed properly.
  */
 class TransformerStreamingTest {
 
@@ -125,26 +127,36 @@ class TransformerStreamingTest {
 
     static Stream<Arguments> testData() throws IOException {
         final List<Arguments> lst = new ArrayList<>();
-        final var props = new HashMap<>();
-        props.put(FORMAT_OUTPUT_TYPE_CONFIG.key(), "avro");
+        final Map<String, String> props = new HashMap<>();
+        OutputFormatFragment.setter(props).withFormatType(FormatType.AVRO);
+        FileNameFragment.setter(props).template(".*");
         lst.add(Arguments.of(TransformerFactory.getTransformer(InputFormat.AVRO),
-                AvroTransformerTest.generateMockAvroData(100).toByteArray(), new SourceCommonConfig(
-                        SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null)), props) {
+                AvroTransformerTest.generateMockAvroData(100).toByteArray(),
+                new SourceCommonConfig(
+                        FileNameFragment.update(
+                                SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null))),
+                        props) {
                 }, 100));
         lst.add(Arguments.of(TransformerFactory.getTransformer(InputFormat.BYTES),
                 "Hello World".getBytes(StandardCharsets.UTF_8),
                 new SourceCommonConfig(
-                        TransformerFragment.update(
-                                SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null))),
+                        FileNameFragment.update(TransformerFragment.update(
+                                SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null)))),
                         props) {
                 }, 1));
         lst.add(Arguments.of(TransformerFactory.getTransformer(InputFormat.JSONL),
-                JsonTransformerTest.getJsonRecs(100).getBytes(StandardCharsets.UTF_8), new SourceCommonConfig(
-                        SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null)), props) {
+                JsonTransformerTest.getJsonRecs(100).getBytes(StandardCharsets.UTF_8),
+                new SourceCommonConfig(
+                        FileNameFragment.update(
+                                SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null))),
+                        props) {
                 }, 100));
         lst.add(Arguments.of(TransformerFactory.getTransformer(InputFormat.PARQUET),
-                ParquetTransformerTest.generateMockParquetData(), new SourceCommonConfig(
-                        SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null)), props) {
+                ParquetTransformerTest.generateMockParquetData(),
+                new SourceCommonConfig(
+                        FileNameFragment.update(
+                                SourceConfigFragment.update(OutputFormatFragment.update(new ConfigDef(), null))),
+                        props) {
                 }, 100));
         return lst.stream();
     }

--- a/s3-commons/src/main/java/io/aiven/kafka/connect/config/s3/S3CommonConfig.java
+++ b/s3-commons/src/main/java/io/aiven/kafka/connect/config/s3/S3CommonConfig.java
@@ -16,14 +16,13 @@
 
 package io.aiven.kafka.connect.config.s3;
 
-import static io.aiven.kafka.connect.config.s3.S3ConfigFragment.AWS_S3_PREFIX_CONFIG;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
 import io.aiven.kafka.connect.common.config.FileNameFragment;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +39,8 @@ public final class S3CommonConfig {
     }
 
     public static Map<String, String> handleDeprecatedYyyyUppercase(final Map<String, String> properties) {
-        List<String> keysToProcess = List.of(S3ConfigFragment.AWS_S3_PREFIX_CONFIG, FileNameFragment.FILE_NAME_TEMPLATE_CONFIG, FileNameFragment.FILE_PATH_PREFIX_TEMPLATE_CONFIG);
+        final List<String> keysToProcess = List.of(S3ConfigFragment.AWS_S3_PREFIX_CONFIG,
+                FileNameFragment.FILE_NAME_TEMPLATE_CONFIG, FileNameFragment.FILE_PATH_PREFIX_TEMPLATE_CONFIG);
         if (keysToProcess.stream().noneMatch(properties::containsKey)) {
             return properties;
         }

--- a/s3-commons/src/main/java/io/aiven/kafka/connect/config/s3/S3CommonConfig.java
+++ b/s3-commons/src/main/java/io/aiven/kafka/connect/config/s3/S3CommonConfig.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import io.aiven.kafka.connect.common.config.FileNameFragment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,12 +40,13 @@ public final class S3CommonConfig {
     }
 
     public static Map<String, String> handleDeprecatedYyyyUppercase(final Map<String, String> properties) {
-        if (!properties.containsKey(AWS_S3_PREFIX_CONFIG)) {
+        List<String> keysToProcess = List.of(S3ConfigFragment.AWS_S3_PREFIX_CONFIG, FileNameFragment.FILE_NAME_TEMPLATE_CONFIG, FileNameFragment.FILE_PATH_PREFIX_TEMPLATE_CONFIG);
+        if (keysToProcess.stream().noneMatch(properties::containsKey)) {
             return properties;
         }
 
         final var result = new HashMap<>(properties);
-        for (final var prop : List.of(AWS_S3_PREFIX_CONFIG)) {
+        for (final var prop : keysToProcess) {
             if (properties.containsKey(prop)) {
                 String template = properties.get(prop);
                 final String originalTemplate = template;

--- a/s3-sink-connector/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
+++ b/s3-sink-connector/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
@@ -598,21 +598,6 @@ final class S3SinkConfigTest {
     }
 
     @Test
-    void notSupportYyyyUppercaseInFilenameTemplate() {
-        final Map<String, String> properties = Map.of(S3SinkConfig.FILE_NAME_TEMPLATE_CONFIG,
-                "{{topic}}-" + "{{timestamp:unit=YYYY}}" + "-{{partition}}-{{start_offset:padding=true}}.gz",
-                S3ConfigFragment.AWS_ACCESS_KEY_ID_CONFIG, "any_access_key_id",
-                S3ConfigFragment.AWS_SECRET_ACCESS_KEY_CONFIG, "any_secret_key",
-                S3ConfigFragment.AWS_S3_BUCKET_NAME_CONFIG, "any-bucket");
-        assertThatThrownBy(() -> new S3SinkConfig(properties)).isInstanceOf(ConfigException.class)
-                .hasMessage(
-                        "Invalid value {{topic}}-{{timestamp:unit=YYYY}}-{{partition}}-{{start_offset:padding=true}}.gz "
-                                + "for configuration file.name.template: unsupported set of template variables parameters, "
-                                + "supported sets are: "
-                                + "partition:padding=true|false,start_offset:padding=true|false,timestamp:unit=yyyy|MM|dd|HH");
-    }
-
-    @Test
     void stsRoleCorrectConfig() {
         final var props = new HashMap<String, String>();
 

--- a/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/AwsIntegrationTest.java
+++ b/s3-source-connector/src/integration-test/java/io/aiven/kafka/connect/s3/source/AwsIntegrationTest.java
@@ -74,7 +74,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Testcontainers
 @SuppressWarnings("PMD.ExcessiveImports")
 class AwsIntegrationTest implements IntegrationBase {
-
     private static final String COMMON_PREFIX = "s3-source-connector-for-apache-kafka-AWS-test-";
 
     @Container

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfig.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfig.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigDef;
 
+import io.aiven.kafka.connect.common.config.FileNameFragment;
 import io.aiven.kafka.connect.common.config.SourceCommonConfig;
 import io.aiven.kafka.connect.common.config.SourceConfigFragment;
 import io.aiven.kafka.connect.common.config.TransformerFragment;
@@ -54,7 +55,7 @@ final public class S3SourceConfig extends SourceCommonConfig {
         S3ConfigFragment.update(configDef);
         SourceConfigFragment.update(configDef);
         TransformerFragment.update(configDef);
-
+        FileNameFragment.update(configDef);
         return configDef;
     }
 

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfigTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/config/S3SourceConfigTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 
+import io.aiven.kafka.connect.common.config.FileNameFragment;
 import io.aiven.kafka.connect.common.source.input.InputFormat;
 import io.aiven.kafka.connect.config.s3.S3ConfigFragment;
 
@@ -41,6 +42,7 @@ final class S3SourceConfigTest {
         props.put(S3ConfigFragment.AWS_S3_ENDPOINT_CONFIG, "AWS_S3_ENDPOINT");
         props.put(S3ConfigFragment.AWS_S3_PREFIX_CONFIG, "AWS_S3_PREFIX");
         props.put(S3ConfigFragment.AWS_S3_REGION_CONFIG, Region.US_EAST_1.id());
+        FileNameFragment.setter(props).template(".*");
 
         // record, topic specific props
         props.put(INPUT_FORMAT_KEY, InputFormat.AVRO.getValue());

--- a/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/AWSV2SourceClientTest.java
+++ b/s3-source-connector/src/test/java/io/aiven/kafka/connect/s3/source/utils/AWSV2SourceClientTest.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import io.aiven.kafka.connect.common.config.FileNameFragment;
 import io.aiven.kafka.connect.s3.source.config.S3SourceConfig;
 
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,7 @@ class AWSV2SourceClientTest {
         final Map<String, String> configMap = new HashMap<>();
 
         configMap.put(AWS_S3_BUCKET_NAME_CONFIG, "test-bucket");
+        FileNameFragment.setter(configMap).template(".*");
         return configMap;
     }
 


### PR DESCRIPTION
Adds fluent setters for fragments to set the values of the config options for testing.

For example:

FileNameFragment has a setter that will set the compression type and template in the configuration as by executing:

```java

Map<String,String> config = new HashMap<>();
FileNameFragment.setter(config).fileCompression(CompressionType.GZIP).template("{{timestamp}}.gz");
```

This PR covers creating the setters and some minor changes to support them.
Not all tests have not been updated to use them.