### PR TITLE
Config to allow source connectors skip to specific native key on start up 

### DIFF
--- a/azure-source-connector/README.md
+++ b/azure-source-connector/README.md
@@ -3,3 +3,8 @@
 The Azure source connector follows the general source processes outline in the Source Design Strategy document.  It does not deviate from that process.
 
 Objects in the data store are retrieved in the lexical order that the Azure blob storage stores them.
+
+
+## Config
+The property `native.start.key` can be used with a continuationToken, if the data in the container is static and no blobs are being added or deleted.
+Discussion on continuationToken on github [here]('https://github.com/Azure/azure-sdk-for-net/issues/17222#issuecomment-736721165')

--- a/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/AzureBlobSourceRecordIterator.java
+++ b/azure-source-connector/src/main/java/io/aiven/kafka/connect/azure/source/utils/AzureBlobSourceRecordIterator.java
@@ -77,6 +77,11 @@ public final class AzureBlobSourceRecordIterator
     }
 
     @Override
+    protected String parseNativeKey(final String nativeKeyText) {
+        return nativeKeyText;
+    }
+
+    @Override
     protected AzureBlobSourceRecord createSourceRecord(final BlobItem nativeObject) {
         return new AzureBlobSourceRecord(nativeObject);
     }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceCommonConfig.java
@@ -82,4 +82,8 @@ public class SourceCommonConfig extends CommonConfig {
     public String getSourceName() {
         return fileNameFragment.getSourceName();
     }
+
+    public String getNativeStartKey() {
+        return sourceConfigFragment.getNativeStartKey();
+    }
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceConfigFragment.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/config/SourceConfigFragment.java
@@ -43,6 +43,8 @@ public final class SourceConfigFragment extends ConfigFragment {
     /* public so that deprecated users can reference it */
     public static final String RING_BUFFER_SIZE = "ring.buffer.size";
 
+    public static final String NATIVE_START_KEY = "native.start.key";
+
     /**
      * Gets a setter for this fragment.
      *
@@ -82,6 +84,10 @@ public final class SourceConfigFragment extends ConfigFragment {
                 new ObjectDistributionStrategyValidator(), ConfigDef.Importance.MEDIUM,
                 "Based on tasks.max config and the type of strategy selected, objects are processed in distributed"
                         + " way by Kafka connect workers.");
+
+        // TODO FIX ME this should be updated to add 'since version 3.4.2' when ExtendedConfigKey is used.
+        configDef.define(NATIVE_START_KEY, ConfigDef.Type.STRING, null, null, ConfigDef.Importance.MEDIUM,
+                "An identifier for the source connector to know which key to start processing from, on a restart it will also begin reading messages from this point as well. Available since 3.4.2");
 
         return configDef;
     }
@@ -129,6 +135,15 @@ public final class SourceConfigFragment extends ConfigFragment {
      */
     public int getRingBufferSize() {
         return cfg.getInt(RING_BUFFER_SIZE);
+    }
+
+    /**
+     * Gets the nativeStartKey.
+     *
+     * @return the key to start consuming records from.
+     */
+    public String getNativeStartKey() {
+        return cfg.getString(NATIVE_START_KEY);
     }
 
     /**
@@ -241,6 +256,17 @@ public final class SourceConfigFragment extends ConfigFragment {
          */
         public Setter ringBufferSize(final int ringBufferSize) {
             return setValue(RING_BUFFER_SIZE, ringBufferSize);
+        }
+
+        /**
+         * Sets the initial native key to start from.
+         *
+         * @param nativeStartKey
+         *            the key to start reading new messages from.
+         * @return this.
+         */
+        public Setter nativeStartKey(final String nativeStartKey) {
+            return setValue(NATIVE_START_KEY, nativeStartKey);
         }
     }
 }

--- a/commons/src/main/java/io/aiven/kafka/connect/common/source/AbstractSourceRecordIterator.java
+++ b/commons/src/main/java/io/aiven/kafka/connect/common/source/AbstractSourceRecordIterator.java
@@ -28,6 +28,7 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 
 import io.aiven.commons.collections.RingBuffer;
 import io.aiven.kafka.connect.common.config.SourceCommonConfig;
+import io.aiven.kafka.connect.common.config.SourceConfigFragment;
 import io.aiven.kafka.connect.common.source.input.Transformer;
 import io.aiven.kafka.connect.common.source.input.utils.FilePatternUtils;
 import io.aiven.kafka.connect.common.source.task.Context;
@@ -36,6 +37,7 @@ import io.aiven.kafka.connect.common.source.task.DistributionType;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.function.IOSupplier;
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 
 /**
@@ -91,6 +93,8 @@ public abstract class AbstractSourceRecordIterator<K extends Comparable<K>, N, O
      */
     private final RingBuffer<K> ringBuffer;
 
+    private final K nativeStartKey;
+
     /**
      * Constructor.
      *
@@ -116,6 +120,9 @@ public abstract class AbstractSourceRecordIterator<K extends Comparable<K>, N, O
         this.transformer = transformer;
         this.taskId = sourceConfig.getTaskId() % maxTasks;
         this.taskAssignment = new TaskAssignment(distributionType.getDistributionStrategy(maxTasks));
+        this.nativeStartKey = sourceConfig.getNativeStartKey() != null
+                ? parseNativeKey(sourceConfig.getNativeStartKey())
+                : null;
         this.fileMatching = new FileMatching(new FilePatternUtils(sourceConfig.getSourceName()));
         this.inner = Collections.emptyIterator();
         this.outer = Collections.emptyIterator();
@@ -137,6 +144,14 @@ public abstract class AbstractSourceRecordIterator<K extends Comparable<K>, N, O
      * @return A stream of natvie objects. May be empty but not {@code null}.
      */
     abstract protected Stream<N> getNativeItemStream(K offset);
+
+    /**
+     *
+     * @param nativeKeyText
+     *            The native identifier to begin consuming events from
+     * @return A transformed native Key into the correct type for processing the specific native key implementation
+     */
+    protected abstract K parseNativeKey(String nativeKeyText);
 
     /**
      * Gets an IOSupplier for the specific source record.
@@ -192,11 +207,11 @@ public abstract class AbstractSourceRecordIterator<K extends Comparable<K>, N, O
             offsetManager.removeEntry(getOffsetManagerKey(lastSeenNativeKey));
         }
         if (!inner.hasNext() && !outer.hasNext()) {
-            inner = getNativeItemStream(ringBuffer.getNextEjected()).map(fileMatching)
-                    .filter(taskAssignment)
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .iterator();
+            inner = getNativeItemStream(ObjectUtils.getIfNull(ringBuffer.getNextEjected(), () -> {
+                getLogger().info("{} set, no alternative present in buffer will begin consuming from {}",
+                        SourceConfigFragment.NATIVE_START_KEY, nativeStartKey);
+                return nativeStartKey;
+            })).map(fileMatching).filter(taskAssignment).filter(Optional::isPresent).map(Optional::get).iterator();
         }
         while (!outer.hasNext() && inner.hasNext()) {
             outer = convert(inner.next()).iterator();

--- a/commons/src/test/java/io/aiven/kafka/connect/common/source/impl/ExampleSourceRecordIterator.java
+++ b/commons/src/test/java/io/aiven/kafka/connect/common/source/impl/ExampleSourceRecordIterator.java
@@ -80,4 +80,9 @@ final public class ExampleSourceRecordIterator
     protected OffsetManager.OffsetManagerKey getOffsetManagerKey(final String nativeKey) {
         return new ExampleOffsetManagerEntry(nativeKey, "three").getManagerKey();
     }
+
+    @Override
+    protected String parseNativeKey(final String nativeKeyText) {
+        return nativeKeyText;
+    }
 }

--- a/s3-source-connector/README.md
+++ b/s3-source-connector/README.md
@@ -69,6 +69,9 @@ subdirectories in the bucket.
 `<filename>` is the file name. The connector has the configurable
 template for file names.
 
+Set the property `native.start.key` with an object key to begin processing objects from **AFTER** that key.
+In the event of a restart the connector will restart from this object key.
+
 The configuration property `file.name.template` is **mandatory**. If not set **no objects will be processed**.
 
 The file name format supports placeholders with variable names of the form: `{{variable_name}}`.  The currently, supported variables are:

--- a/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecordIterator.java
+++ b/s3-source-connector/src/main/java/io/aiven/kafka/connect/s3/source/utils/S3SourceRecordIterator.java
@@ -82,6 +82,11 @@ public final class S3SourceRecordIterator
     }
 
     @Override
+    protected String parseNativeKey(final String nativeKeyText) {
+        return nativeKeyText;
+    }
+
+    @Override
     protected S3SourceRecord createSourceRecord(final S3Object nativeObject) {
         return new S3SourceRecord(nativeObject);
     }


### PR DESCRIPTION
Introduces a configuration object to allow s3-source users to select a starting object key.

This does not cover restart scenarios and on a restart this would start scanning from the original object key that was supplied or if none was supplied from the beginning of the bucket.