### PR TITLE
Update to readme document to show how to process any files with a regex

### DIFF
--- a/s3-sink-connector/README.md
+++ b/s3-sink-connector/README.md
@@ -506,6 +506,8 @@ List of new configuration parameters:
 - `timestamp.timezone` - The time zone in which timestamps are represented. Accepts short and long standard names like: `UTC`, `PST`, `ECT`, `Europe/Berlin`, `Europe/Helsinki`, or `America/New_York`. For more information please refer to https://docs.oracle.com/javase/tutorial/datetime/iso/timezones.html. The default is `UTC`.
 - `timestamp.source` -  The source of timestamps. Supports only `wallclock` which is the default value.
 
+The `file.compression.type` defaults to `gzip`, when being used with the s3-source connector, ensure that the source connector is set to the same compression type as by default. The source connector defaults to `none`.
+
 ## Configuration
 
 [Here](https://kafka.apache.org/documentation/#connect_running) you can

--- a/s3-source-connector/README.md
+++ b/s3-source-connector/README.md
@@ -74,7 +74,7 @@ In the event of a restart the connector will restart from this object key.
 
 The configuration property `file.name.template` is **mandatory**. If not set **no objects will be processed**.
 
-From version 3.4.0 when using "object_hash" distribution type it is possible to set this to ".*" to match all object keys or use a regex to match specific object keys. When using partition distribution type you must use the placeholders described below.
+From version 3.4.0, when using the `object_hash` distribution type, you can set this to `.*` to match all object keys or use a regular expression to match specific object keys. When using the partition distribution type, you must use the placeholders described below.
 
 The file name format supports placeholders with variable names of the form: `{{variable_name}}`.  The currently, supported variables are:
 
@@ -207,6 +207,8 @@ the final `Avro` schema for `Parquet` is:
 ```
 **Note:** The connector works just fine with and without a schema registry.
 
+### Compression type
+`file.compression.type`: Compression type for input files. Supported algorithms: `gzip`, `snappy`, `zstd`, and `none`. Defaults to `none`. If used with the S3 sink connector, ensure both connectors use the same compression type. The sink connector defaults to `gzip`.
 
 ### Acked Records
 


### PR DESCRIPTION
In 3.4.0 we updated the validation to allow the source connector to use a simple regex which would scan for files to read. This was not documented and adds a considerable amount of flexibility.


Also updated the fact that the sink connector compression defaults to gzip and the source defaults to none.