### PR TITLE
Bump testcontainers from 1.20.6 to 2.0.2.

### DIFF
--- a/commons/src/testFixtures/java/io/aiven/kafka/connect/common/format/ParquetTestDataFixture.java
+++ b/commons/src/testFixtures/java/io/aiven/kafka/connect/common/format/ParquetTestDataFixture.java
@@ -42,11 +42,11 @@ import io.aiven.kafka.connect.common.output.parquet.ParquetOutputWriter;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.SeekableInputStream;
-import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
 
 /**
  * A testing feature to generate/read Parquet data.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,7 +26,7 @@ val slf4jVersion by extra("1.7.36")
 val snappyVersion by extra("1.1.10.5")
 val spotbugsAnnotationsVersion by extra("4.8.1")
 val stax2ApiVersion by extra("4.2.2")
-val testcontainersVersion by extra("1.20.6")
+val testcontainersVersion by extra("2.0.2")
 val zstdVersion by extra("1.5.6-3")
 val wireMockVersion by extra("2.35.0")
 val azureVersion by extra("12.30.0")
@@ -113,11 +113,14 @@ dependencyResolutionManagement {
       library("woodstox-stax2-api", "org.codehaus.woodstox:stax2-api:$stax2ApiVersion")
     }
     create("testcontainers") {
-      library("junit-jupiter", "org.testcontainers:junit-jupiter:$testcontainersVersion")
       library(
-          "kafka", "org.testcontainers:kafka:$testcontainersVersion") // this is not Kafka version
-      library("localstack", "org.testcontainers:localstack:$testcontainersVersion")
-      library("azure", "org.testcontainers:azure:$testcontainersVersion")
+          "junit-jupiter", "org.testcontainers:testcontainers-junit-jupiter:$testcontainersVersion")
+      library(
+          "kafka",
+          "org.testcontainers:testcontainers-kafka:$testcontainersVersion") // this is not Kafka
+      // version
+      library("localstack", "org.testcontainers:testcontainers-localstack:$testcontainersVersion")
+      library("azure", "org.testcontainers:testcontainers-azure:$testcontainersVersion")
     }
   }
 }


### PR DESCRIPTION
This is necessary for new versions of docker (in my case 29.02), fixing https://github.com/testcontainers/testcontainers-java/issues/11212

```
Caused by: java.lang.IllegalStateException: Could not find a valid Docker environment. Please see logs and check configuration
	at org.testcontainers.dockerclient.DockerClientProviderStrategy.lambda$getFirstValidStrategy$7(DockerClientProviderStrategy.java:274)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at org.testcontainers.dockerclient.DockerClientProviderStrategy.getFirstValidStrategy(DockerClientProviderStrategy.java:265)
	at org.testcontainers.DockerClientFactory.getOrInitializeStrategy(DockerClientFactory.java:154)
	at org.testcontainers.DockerClientFactory.getRemoteDockerUnixSocketPath(DockerClientFactory.java:165)
	at org.testcontainers.containers.localstack.LocalStackContainer.<init>(LocalStackContainer.java:124)
	at org.testcontainers.containers.localstack.LocalStackContainer.<init>(LocalStackContainer.java:106)
	at io.aiven.kakfa.connect.s3.source.testdata.AWSIntegrationTestData.createS3Container(AWSIntegrationTestData.java:68)
	at io.aiven.kafka.connect.s3.source.S3SourceTaskTest.<clinit>(S3SourceTaskTest.java:91)
	... 74 more
```

Fixes: #565 

