### PR TITLE
Apply the externalId to STS AssumeRoleRequests

### DIFF
--- a/s3-commons/src/main/java/io/aiven/kafka/connect/iam/AwsCredentialProviderFactory.java
+++ b/s3-commons/src/main/java/io/aiven/kafka/connect/iam/AwsCredentialProviderFactory.java
@@ -108,6 +108,7 @@ public class AwsCredentialProviderFactory {
             return StsAssumeRoleCredentialsProvider.builder()
                     .refreshRequest(() -> AssumeRoleRequest.builder()
                             .roleArn(config.getStsRole().getArn())
+                            .externalId(config.getStsRole().getExternalId())
                             // Maker this a unique identifier
                             .roleSessionName("AwsV2SDKConnectorSession")
                             .build())


### PR DESCRIPTION
It doesn't appear that the external ID is exposed in a testable way for the `requestRefresh()`

Fixes: #564 