### PR TITLE
docs(gcs-sink): document file.max.bytes and file.max.records configuration properties

### DIFF
--- a/gcs-sink-connector/README.md
+++ b/gcs-sink-connector/README.md
@@ -632,6 +632,14 @@ file.name.timestamp.source=wallclock
 # Optional, the default is `{{topic}}-{{partition:padding=false}}-{{start_offset:padding=false}}` or
 # `{{topic}}-{{partition:padding=false}}-{{start_offset:padding=false}}.gz` if the compression is enabled.
 file.name.template={{topic}}-{{partition:padding=true}}-{{start_offset:padding=true}}.gz
+
+# The maximum number of bytes to put in a single file. Must be a non-negative
+# integer number. The default is 0, which means unlimited.
+file.max.bytes=0
+
+# The maximum number of records to put in a single file. Must be a non-negative
+# integer number. The default is 0, which means unlimited.
+file.max.records=0
 ```
 
 ## Getting releases


### PR DESCRIPTION
Document GCS sink configs introduced by https://github.com/Aiven-Open/cloud-storage-connectors-for-apache-kafka/pull/594.

These configurations are explained in more detail in https://github.com/Aiven-Open/cloud-storage-connectors-for-apache-kafka/issues/270#issuecomment-3850016894.